### PR TITLE
Fix: Install libegl1 for PySide6 on Linux CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install Qt dependencies (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update && sudo apt-get install -y libegl1
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- Install `libegl1` on Ubuntu runners before pip install — PySide6 needs `libEGL.so.1` at import time

## Test plan
- [ ] CI goes green on this PR (Linux jobs no longer fail with ImportError)

🤖 Generated with [Claude Code](https://claude.com/claude-code)