### PR TITLE
Fix: QT_QPA_PLATFORM=offscreen for headless Linux CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
     - name: Run tests with pytest
       run: |
         pytest
+      env:
+        QT_QPA_PLATFORM: ${{ runner.os == 'Linux' && 'offscreen' || '' }}
 
     - name: Upload coverage reports to Codecov
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,8 @@ jobs:
 
     - name: Run tests
       run: pytest
+      env:
+        QT_QPA_PLATFORM: offscreen
 
     - name: Build with PyInstaller
       run: pyinstaller NCRomEditor.spec --noconfirm


### PR DESCRIPTION
## Summary
- PySide6 crashes with SIGABRT (exit 134) on headless Linux runners — needs `QT_QPA_PLATFORM=offscreen`
- Applied to both `ci.yml` and `release.yml` test steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)