### PR TITLE
Fix README image width for GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/NCRomEditor3D.png" alt="NC ROM Editor" max-width="40%">
+  <img src="assets/NCRomEditor3D.png" alt="NC ROM Editor" width="40%">
 </p>
 
 # NC ROM Editor


### PR DESCRIPTION
## Summary
- Replace `max-width` with `width` on the logo image — GitHub strips `max-width` from img tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)