### PR TITLE
fix: Black formatting and PyInstaller spec path resolution

### DIFF
--- a/main.py
+++ b/main.py
@@ -260,9 +260,7 @@ class MainWindow(QMainWindow, RecentFilesMixin, ProjectMixin, SessionMixin):
         # Check if directory contains at least one XML file
         xml_files = list(metadata_path.glob("*.xml"))
         if not xml_files:
-            logger.warning(
-                f"No XML files found in metadata directory: {metadata_dir}"
-            )
+            logger.warning(f"No XML files found in metadata directory: {metadata_dir}")
             return False
 
         return True

--- a/packaging/NCRomEditor.spec
+++ b/packaging/NCRomEditor.spec
@@ -11,17 +11,19 @@ import sys
 
 block_cipher = None
 
+# Resolve paths relative to the repository root (one level up from this spec file)
+repo_root = os.path.abspath(os.path.join(SPECPATH, '..'))
+
 # Icon: .ico on Windows, skip on Linux (desktop icons use .desktop files)
-icon_file = 'assets/NCRomEditor.ico' if sys.platform == 'win32' else None
+icon_file = os.path.join(repo_root, 'assets', 'NCRomEditor.ico') if sys.platform == 'win32' else None
 
 a = Analysis(
-    ['main.py'],
-    pathex=[],
+    [os.path.join(repo_root, 'main.py')],
+    pathex=[repo_root],
     binaries=[],
     datas=[
-        ('examples/metadata', 'examples/metadata'),
-        ('colormaps', 'colormaps'),
-        ('examples', 'examples'),
+        (os.path.join(repo_root, 'colormaps'), 'colormaps'),
+        (os.path.join(repo_root, 'examples'), 'examples'),
     ],
     hiddenimports=[],
     hookspath=[],

--- a/src/core/rom_detector.py
+++ b/src/core/rom_detector.py
@@ -67,9 +67,7 @@ class RomDetector:
         if not self.definitions_dir.is_dir():
             raise MetadataDirectoryError(f"Path is not a directory: {metadata_dir}")
 
-        logger.info(
-            f"Initializing ROM detector with metadata dir: {metadata_dir}"
-        )
+        logger.info(f"Initializing ROM detector with metadata dir: {metadata_dir}")
         self.rom_definitions: List[RomIdInfo] = []
         self._scan_definitions()
         logger.info(f"Found {len(self.rom_definitions)} ROM definition(s)")

--- a/src/ui/settings_dialog.py
+++ b/src/ui/settings_dialog.py
@@ -99,9 +99,7 @@ class SettingsDialog(QDialog):
         # Metadata directory setting
         metadata_layout = QHBoxLayout()
         self.metadata_path_edit = QLineEdit()
-        self.metadata_path_edit.setPlaceholderText(
-            "Path to ROM metadata XML files"
-        )
+        self.metadata_path_edit.setPlaceholderText("Path to ROM metadata XML files")
         metadata_layout.addWidget(self.metadata_path_edit)
 
         browse_button = QPushButton("Browse...")
@@ -118,9 +116,7 @@ class SettingsDialog(QDialog):
         # Export directory setting
         export_layout = QHBoxLayout()
         self.export_path_edit = QLineEdit()
-        self.export_path_edit.setPlaceholderText(
-            "Folder for CSV exports"
-        )
+        self.export_path_edit.setPlaceholderText("Folder for CSV exports")
         export_layout.addWidget(self.export_path_edit)
 
         browse_export_button = QPushButton("Browse...")

--- a/src/ui/setup_wizard.py
+++ b/src/ui/setup_wizard.py
@@ -104,9 +104,7 @@ class RomDropFolderPage(QWizardPage):
         layout.addLayout(path_layout)
 
         # Help text
-        help_label = QLabel(
-            "Example: C:/Projets/MiataNC/romdrop_rev_21053000"
-        )
+        help_label = QLabel("Example: C:/Projets/MiataNC/romdrop_rev_21053000")
         help_label.setStyleSheet("color: gray; font-size: 10px; font-style: italic;")
         help_label.setAlignment(Qt.AlignCenter)
         layout.addWidget(help_label)

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -28,7 +28,9 @@ class AppSettings:
         """
         # Default to 'examples/metadata' directory in the application root
         default_path = str(get_app_root() / "examples" / "metadata")
-        return os.path.normpath(self.settings.value("paths/metadata_directory", default_path))
+        return os.path.normpath(
+            self.settings.value("paths/metadata_directory", default_path)
+        )
 
     def set_metadata_directory(self, path: str):
         """
@@ -170,7 +172,9 @@ class AppSettings:
         """
         # Default to the built-in default.map in the colormaps directory
         default_path = str(get_app_root() / "colormaps" / "default.map")
-        return os.path.normpath(self.settings.value("display/colormap_path", default_path))
+        return os.path.normpath(
+            self.settings.value("display/colormap_path", default_path)
+        )
 
     def set_colormap_path(self, path: str):
         """
@@ -189,7 +193,9 @@ class AppSettings:
             str: Path to directory containing .map files
         """
         default_path = str(get_app_root() / "colormaps")
-        return os.path.normpath(self.settings.value("paths/colormap_directory", default_path))
+        return os.path.normpath(
+            self.settings.value("paths/colormap_directory", default_path)
+        )
 
     def set_colormap_directory(self, path: str):
         """
@@ -208,7 +214,9 @@ class AppSettings:
             str: Path to export directory
         """
         default_path = str(get_user_data_dir() / "exports")
-        return os.path.normpath(self.settings.value("paths/export_directory", default_path))
+        return os.path.normpath(
+            self.settings.value("paths/export_directory", default_path)
+        )
 
     def set_export_directory(self, path: str):
         """
@@ -227,7 +235,9 @@ class AppSettings:
             str: Path to directory where projects are stored
         """
         default_path = str(get_user_data_dir() / "projects")
-        return os.path.normpath(self.settings.value("paths/projects_directory", default_path))
+        return os.path.normpath(
+            self.settings.value("paths/projects_directory", default_path)
+        )
 
     def set_projects_directory(self, path: str):
         """


### PR DESCRIPTION
## Summary
- Fix black formatting on 5 files that failed CI lint check
- Fix PyInstaller spec to resolve all paths relative to repo root using `SPECPATH`, so `pyinstaller packaging/NCRomEditor.spec` works from any CWD

## Test plan
- [x] `black --check` passes
- [x] `pytest` — 318 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)