### PR TITLE
feat: Project management refactor — tuning log with mandatory snapshots

### DIFF
--- a/.claude/notes.md
+++ b/.claude/notes.md
@@ -2,7 +2,23 @@
 
 ## Next Tasks
 - Focus on the first value field of a table immediately after opening a table.
-- **Project/versioning system** - Full rewrite planned (current code excluded from audit)
+
+## Recent Completed Work (Mar 1, 2026) - Project Management Refactor: Tuning Log with Mandatory Snapshots
+- **Tuning log auto-generation** — Every commit appends a markdown section to `TUNING_LOG.md` with version name, description, table change summary (count + direction: ↑/↓/→/~ with avg %), based-on reference, ROM filename, and a "Results" placeholder. Header written on project creation with vehicle/ECU/checksum info.
+- **Mandatory version snapshots** — Removed optional snapshot checkbox from commit flow. Every commit always creates `v{N}_{ROMID}_{name}.bin`. Version name is required and auto-sanitized (lowercase, spaces→underscores, strip special chars).
+- **Soft delete versions** — `soft_delete_version()` moves snapshot to `_trash/`, marks `deleted=True` in commits.json. Cannot delete v0.
+- **Revert to version** — `revert_to_version()` loads snapshot bytes, overwrites working ROM, soft-deletes all newer versions. Appends revert entry to tuning log.
+- **Simplified working ROM naming** — Changed from `v1_{ROMID}_working.bin` to `{ROMID}.bin`. Old projects still work (backward compat via `project.json.working_rom` field).
+- **Removed `--enable-projects` feature flag** — Projects are now always enabled. Removed `projects_enabled` from main.py, session_mixin.py, recent_files_mixin.py, settings_dialog.py, run-dev.bat. All project menu items always visible.
+- **Commit dialog redesigned** — Single required version name field with auto-sanitization and real-time filename preview. Optional message field. Removed snapshot checkbox, suffix field, and `QuickCommitDialog`.
+- **History viewer enhancements** — Added "Revert to this version" and "Delete this version" buttons. Deleted commits hidden by default with "Show deleted" toggle. Deleted items shown with strikethrough + gray when toggled on.
+- **Version model cleanup** — Added `deleted: bool` to Commit dataclass. Removed `last_suffix` and `settings` from Project dataclass.
+- **37 new tests** — Full coverage for: create_project (working ROM naming, tuning log, v0), commit_changes (snapshot, tuning log, direction, sequential versions), soft_delete (trash, marks, persistence, guards), revert (overwrite, cascade delete, log, v0, monotonic), backward compat, commit dialog sanitization.
+- **History viewer polish** — Snapshot filename as primary column (removed Version+Message columns), "Show deleted" toggle, read-only CompareWindow for version diffs (single instance, parented to history dialog so it appears on top), git-log style toolbar icon for version history (enabled when project is open).
+- **Default author to system user** — `Commit.create()` uses `os.getlogin()` instead of hardcoded "User".
+- **Window geometry persistence** — History viewer and compare window save/restore size, splitter position, and column widths via QSettings. History viewer uses `done()` override (not `closeEvent`) since `accept()` doesn't trigger `closeEvent` on modal dialogs.
+- **Commit clears modified flag** — `document.set_modified(False)` called after successful commit so the close prompt doesn't ask about already-committed changes.
+- **Commit message preserves line breaks** — Newlines in commit messages rendered as `<br>` in the HTML details view.
 
 ## Recent Completed Work (Mar 1, 2026) - RomDrop Setup Wizard & Definitions → Metadata Rename
 - **RomDrop setup wizard** — Rewrote `setup_wizard.py` from single-page definitions directory picker to two-step QWizard: Step 1 selects RomDrop installation folder (validates romdrop.exe + metadata/ presence), Step 2 confirms derived paths with green/red status indicators and editable fields. Saves both `romdrop_executable_path` and `metadata_directory` on completion.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to NC ROM Editor are documented here.
 
+## [Unreleased]
+
+### Added
+- **Tuning log** — Every commit auto-generates a `TUNING_LOG.md` entry with version name, description, table change summary with direction indicators, and a "Results" section to fill in after testing
+- **Revert to version** — Restore a previous ROM snapshot as the working file. Newer versions are soft-deleted. Available from the History viewer
+- **Soft delete versions** — Remove bad snapshots by moving them to `_trash/`. Deleted versions are hidden in history (toggleable with "Show deleted" checkbox)
+- **Version History toolbar button** — Clock icon in the toolbar, enabled when a project is open
+- **Read-only version comparison** — Double-click a table in History or click "Compare Versions..." to open a side-by-side comparison (reuses ROM Compare window with copy buttons hidden)
+- **Window geometry persistence** — History viewer and compare window remember their size, splitter position, and column widths across sessions
+- **37 new tests** for project management: tuning log generation, soft delete, revert, commit flow, backward compatibility
+
+### Changed
+- **Mandatory version names** — Every commit now requires a version name (e.g., "egr_delete") and always creates a named ROM snapshot. The snapshot checkbox and optional suffix have been replaced with a single required field
+- **Simplified working ROM naming** — Working file is now `{ROMID}.bin` instead of `v1_{ROMID}_working.bin`
+- **Projects always enabled** — Removed `--enable-projects` feature flag. Project menu items (New Project, Commit Changes, Commit History) are always visible
+- **Commit dialog redesigned** — Version name field (required, auto-sanitized), filename preview, optional description. Removed snapshot checkbox and QuickCommitDialog
+- **History viewer columns** — Replaced Version + Message columns with a single Snapshot column showing the filename
+- **Commit author defaults to system user** — Uses `os.getlogin()` instead of hardcoded "User"
+
+### Fixed
+- **Commit clears modified flag** — Committing no longer leaves the document marked as modified, preventing a spurious "unsaved changes" prompt on close
+- **Commit message line breaks** — Multi-line commit messages now render correctly in the history details panel
+
+### Removed
+- `--enable-projects` feature flag — projects are now a core feature
+- `last_suffix` and `settings` fields from Project model (dead code)
+- `QuickCommitDialog` class (unused)
+
 ## [v1.5.0] - 2026-03-01
 
 ### Added
@@ -11,7 +39,6 @@ All notable changes to NC ROM Editor are documented here.
 ### Changed
 - **"Definitions" renamed to "Metadata"** — All UI labels, settings keys, CLI flags, and log messages now use "metadata" instead of "definitions" to match RomDrop's naming convention. Settings key changed from `paths/definitions_directory` to `paths/metadata_directory`. MCP server flag changed from `--definitions-dir` to `--metadata-dir`
 - **Bundled XML files moved to examples/metadata/** — The `definitions/` directory has been restructured to `examples/metadata/` since it contains example/bundled data
-- **Projects UI hidden behind feature flag** — Projects directory setting and View menu are now only shown when `--enable-projects` is passed
 - **README updated for Linux** — Installation section now documents Linux `.tar.gz` download alongside Windows
 - **Project structure reorganized** — Moved build/packaging files (`build.bat`, `installer.iss`, `NCRomEditor.spec`, `requirements-build.txt`) into `packaging/` directory; moved `WINDOWS_SETUP.md` into `docs/`
 

--- a/README.md
+++ b/README.md
@@ -221,15 +221,16 @@ nc-rom-editor/
 6. **Save ROM:** File → Save ROM or Save ROM As...
 7. **Flash to ECU:** Tools → Flash ROM to ECU (or `Ctrl+Shift+F`) — launches RomDrop with your ROM file
 
-### Using Projects (Experimental)
+### Using Projects
 
-Projects provide version control for your tuning work. This feature is behind a feature flag — launch with `--enable-projects` to access it (or use `run-dev.bat`).
+Projects provide version control for your tuning work. Every commit creates a named, flashable ROM snapshot and an auto-generated tuning log.
 
 1. **Create Project:** File → New Project → Select a ROM file
-2. **Make Changes:** Edit tables as needed
-3. **Commit:** File → Commit Changes → Enter a description
-4. **View History:** View → History to see all commits
-5. **Compare Versions:** Click any commit to see what changed
+2. **Make Changes:** Edit tables, Ctrl+S saves to the working ROM
+3. **Commit:** File → Commit Changes → Name the version (e.g., "egr_delete") → a snapshot and log entry are created
+4. **View History:** View → Commit History to browse all versions
+5. **Revert:** Select a version in History → "Revert to this version" to restore it
+6. **Delete:** Remove bad versions — snapshots are moved to `_trash/`
 
 ## Development
 

--- a/main.py
+++ b/main.py
@@ -117,9 +117,6 @@ class MainWindow(QMainWindow, RecentFilesMixin, ProjectMixin, SessionMixin):
         # Structure: {rom_path: {table_name: {"values": np.array, "x_axis": np.array, "y_axis": np.array}}}
         self.original_table_values = {}
 
-        # Feature flags
-        self.projects_enabled = "--enable-projects" in sys.argv
-
         # Project management
         self.project_manager = ProjectManager()
         self.change_tracker = ChangeTracker()
@@ -319,10 +316,8 @@ class MainWindow(QMainWindow, RecentFilesMixin, ProjectMixin, SessionMixin):
         # File menu (Alt+F)
         self.file_menu = menubar.addMenu("&File")
 
-        # Project section (hidden unless --enable-projects)
-        if self.projects_enabled:
-            new_project_action = self.file_menu.addAction("New Project...")
-            new_project_action.triggered.connect(self.new_project)
+        new_project_action = self.file_menu.addAction("New Project...")
+        new_project_action.triggered.connect(self.new_project)
 
         open_action = self.file_menu.addAction("Open...")
         open_action.setShortcut("Ctrl+O")
@@ -337,11 +332,9 @@ class MainWindow(QMainWindow, RecentFilesMixin, ProjectMixin, SessionMixin):
 
         self.file_menu.addSeparator()
 
-        # Commit (for projects, hidden unless --enable-projects)
         self.commit_action = self.file_menu.addAction("Commit Changes...")
         self.commit_action.triggered.connect(self.commit_changes)
         self.commit_action.setEnabled(False)
-        self.commit_action.setVisible(self.projects_enabled)
 
         self.file_menu.addSeparator()
 
@@ -382,11 +375,10 @@ class MainWindow(QMainWindow, RecentFilesMixin, ProjectMixin, SessionMixin):
         settings_action = edit_menu.addAction("Settings...")
         settings_action.triggered.connect(self.show_settings)
 
-        # View menu (Alt+V) — only shown when projects are enabled
-        if self.projects_enabled:
-            view_menu = menubar.addMenu("&View")
-            history_action = view_menu.addAction("Commit History...")
-            history_action.triggered.connect(self.show_history)
+        # View menu (Alt+V)
+        view_menu = menubar.addMenu("&View")
+        history_action = view_menu.addAction("Commit History...")
+        history_action.triggered.connect(self.show_history)
 
         # Tools menu (Alt+T)
         tools_menu = menubar.addMenu("&Tools")
@@ -454,6 +446,12 @@ class MainWindow(QMainWindow, RecentFilesMixin, ProjectMixin, SessionMixin):
         act.setToolTip("Compare Open ROMs  (Ctrl+Shift+D)")
         act.triggered.connect(self._on_compare_roms)
         self._toolbar_compare = act
+
+        act = tb.addAction(self._make_icon("history"), "")
+        act.setToolTip("Version History")
+        act.triggered.connect(self.show_history)
+        act.setEnabled(False)
+        self._toolbar_history = act
 
         act = tb.addAction(self._make_icon("flash"), "")
         act.setToolTip("Flash ROM to ECU  (Ctrl+Shift+F)")
@@ -570,6 +568,25 @@ class MainWindow(QMainWindow, RecentFilesMixin, ProjectMixin, SessionMixin):
             p.drawPolygon(poly)
             # Center circle
             p.drawEllipse(QPointF(cx, cy), 2.5, 2.5)
+
+        elif name == "history":
+            # Git-log style: vertical line with commit nodes
+            from PySide6.QtCore import QPointF
+
+            # Vertical trunk line
+            p.setPen(QPen(c, 1.6, Qt.SolidLine, Qt.RoundCap))
+            p.drawLine(7, 2, 7, 18)
+            # Commit dots on the trunk
+            p.setBrush(c)
+            p.setPen(QPen(c, 1.2))
+            p.drawEllipse(QPointF(7, 5), 2.2, 2.2)
+            p.drawEllipse(QPointF(7, 10), 2.2, 2.2)
+            p.drawEllipse(QPointF(7, 15), 2.2, 2.2)
+            # Branch lines from dots to the right
+            p.setPen(QPen(c, 1.2, Qt.SolidLine, Qt.RoundCap))
+            p.drawLine(9, 5, 16, 5)
+            p.drawLine(9, 10, 14, 10)
+            p.drawLine(9, 15, 17, 15)
 
         elif name in ("mcp_on", "mcp_off"):
             # Broadcast / antenna icon — circle with signal waves
@@ -829,7 +846,7 @@ class MainWindow(QMainWindow, RecentFilesMixin, ProjectMixin, SessionMixin):
             return
 
         parent = Path(file_path).parent
-        if self.projects_enabled and ProjectManager.is_project_folder(str(parent)):
+        if ProjectManager.is_project_folder(str(parent)):
             self.open_project_path(str(parent))
         else:
             self._open_rom_file(file_path)
@@ -1521,8 +1538,7 @@ class MainWindow(QMainWindow, RecentFilesMixin, ProjectMixin, SessionMixin):
     def _save(self):
         """Unified save: commit if project is open with changes, otherwise save ROM."""
         if (
-            self.projects_enabled
-            and self.project_manager.is_project_open()
+            self.project_manager.is_project_open()
             and self.change_tracker.has_pending_changes()
         ):
             self.commit_changes()
@@ -2345,10 +2361,12 @@ class MainWindow(QMainWindow, RecentFilesMixin, ProjectMixin, SessionMixin):
         """Update UI elements based on project/change state"""
         # Note: undo/redo action enabled state is managed automatically by QUndoGroup
 
-        # Update commit action
+        # Update commit action and history button
         has_project = self.project_manager.is_project_open()
         has_changes = self.change_tracker.has_pending_changes()
         self.commit_action.setEnabled(has_project and has_changes)
+        if hasattr(self, "_toolbar_history"):
+            self._toolbar_history.setEnabled(has_project)
 
         # Update window title
         if has_project:

--- a/run-dev.bat
+++ b/run-dev.bat
@@ -1,3 +1,3 @@
 @echo off
-REM NC ROM Editor - Dev Launcher (with project management enabled)
-call run.bat --enable-projects
+REM NC ROM Editor - Dev Launcher
+call run.bat %*

--- a/run.bat
+++ b/run.bat
@@ -52,7 +52,7 @@ if errorlevel 1 (
     echo.
 )
 
-REM Run the application (pass any command-line args through, e.g. --enable-projects)
+REM Run the application (pass any command-line args through)
 echo Starting NC ROM Editor...
 echo.
 python main.py %*

--- a/src/core/project_manager.py
+++ b/src/core/project_manager.py
@@ -74,8 +74,8 @@ class ProjectManager:
             v0_path = project_dir / v0_filename
             shutil.copy2(source_path, v0_path)
 
-            # v1 = working ROM (editable copy)
-            working_filename = f"v1_{rom_id}_working.bin"
+            # Working ROM (editable copy, simple name)
+            working_filename = f"{rom_id}.bin"
             working_path = project_dir / working_filename
             shutil.copy2(source_path, working_path)
 
@@ -107,8 +107,6 @@ class ProjectManager:
                 head_commit_id=None,
                 project_path=str(project_dir),
                 head_version=0,
-                last_suffix="original",
-                settings={"auto_snapshot_interval": 10},
             )
 
             # Save project file
@@ -129,6 +127,9 @@ class ProjectManager:
             project.head_commit_id = initial_commit.id
             project.head_version = 0
             self._save_project_file(project)
+
+            # Write initial TUNING_LOG.md
+            self._write_tuning_log_header(project, source_path.name, checksum)
 
             self.current_project = project
             logger.info(f"Created project: {project_name} at {project_path}")
@@ -202,17 +203,15 @@ class ProjectManager:
         self,
         message: str,
         changes: List[TableChanges],
-        create_snapshot: bool = False,
-        snapshot_suffix: str = "",
+        version_name: str,
     ) -> Commit:
         """
-        Create a new commit with pending changes
+        Create a new commit with pending changes. Always creates a ROM snapshot.
 
         Args:
             message: Commit message
             changes: List of table changes
-            create_snapshot: Whether to create a full ROM snapshot
-            snapshot_suffix: User-provided suffix for snapshot filename
+            version_name: Required name for the snapshot (e.g., "egr_delete")
 
         Returns:
             Created Commit object
@@ -228,10 +227,8 @@ class ProjectManager:
             next_version = self.get_next_version()
             rom_id = self.current_project.original_rom.rom_id
 
-            # Generate snapshot filename if creating snapshot
-            snapshot_filename = None
-            if create_snapshot and snapshot_suffix:
-                snapshot_filename = f"v{next_version}_{rom_id}_{snapshot_suffix}.bin"
+            # Always generate snapshot filename
+            snapshot_filename = f"v{next_version}_{rom_id}_{version_name}.bin"
 
             # Create commit with version
             commit = Commit.create(
@@ -242,13 +239,12 @@ class ProjectManager:
                 snapshot_filename=snapshot_filename,
             )
 
-            # Optionally create snapshot at project root
-            if create_snapshot and snapshot_filename:
-                project_dir = Path(self.current_project.project_path)
-                working_path = project_dir / self.current_project.working_rom
-                snapshot_path = project_dir / snapshot_filename
-                shutil.copy2(working_path, snapshot_path)
-                logger.debug(f"Created snapshot: {snapshot_filename}")
+            # Always create snapshot at project root
+            project_dir = Path(self.current_project.project_path)
+            working_path = project_dir / self.current_project.working_rom
+            snapshot_path = project_dir / snapshot_filename
+            shutil.copy2(working_path, snapshot_path)
+            logger.debug(f"Created snapshot: {snapshot_filename}")
 
             # Add to history
             self.commits.append(commit)
@@ -257,9 +253,10 @@ class ProjectManager:
             # Update project head and version
             self.current_project.head_commit_id = commit.id
             self.current_project.head_version = next_version
-            if snapshot_suffix:
-                self.current_project.last_suffix = snapshot_suffix
             self.save_project()
+
+            # Append to tuning log
+            self._append_tuning_log(commit)
 
             tables_str = ", ".join(commit.tables_modified[:3])
             if len(commit.tables_modified) > 3:
@@ -295,10 +292,10 @@ class ProjectManager:
         return [c for c in self.commits if table_name in c.tables_modified]
 
     def get_next_version(self) -> int:
-        """Get the next version number for a new commit"""
-        if not self.current_project:
-            return 0
-        return self.current_project.head_version + 1
+        """Get the next version number for a new commit (always monotonically increasing)"""
+        if not self.commits:
+            return 1
+        return max(c.version for c in self.commits) + 1
 
     def get_commit_by_version(self, version: int) -> Optional[Commit]:
         """Get a commit by its version number"""
@@ -368,6 +365,98 @@ class ProjectManager:
                 return f.read()
         return None
 
+    def soft_delete_version(self, version: int) -> bool:
+        """
+        Move snapshot to _trash/, mark commit as deleted.
+
+        Args:
+            version: Version number to soft-delete
+
+        Returns:
+            True if deleted successfully
+
+        Raises:
+            ProjectError: If version cannot be deleted
+        """
+        if not self.current_project:
+            raise ProjectError("No project is currently open")
+
+        if version == 0:
+            raise ProjectError("Cannot delete the original ROM (v0)")
+
+        commit = self.get_commit_by_version(version)
+        if not commit:
+            raise ProjectError(f"Version {version} not found")
+
+        if commit.deleted:
+            raise ProjectError(f"Version {version} is already deleted")
+
+        project_dir = Path(self.current_project.project_path)
+
+        # Move snapshot file to _trash/
+        if commit.snapshot_filename:
+            snapshot_path = project_dir / commit.snapshot_filename
+            if snapshot_path.exists():
+                trash_dir = project_dir / "_trash"
+                trash_dir.mkdir(exist_ok=True)
+                trash_path = trash_dir / commit.snapshot_filename
+                shutil.move(str(snapshot_path), str(trash_path))
+                logger.debug(f"Moved {commit.snapshot_filename} to _trash/")
+
+        # Mark as deleted
+        commit.deleted = True
+        self._save_commits(self.commits, self.current_project)
+
+        logger.info(f"Soft-deleted version {version}")
+        return True
+
+    def revert_to_version(self, version: int) -> str:
+        """
+        Load snapshot, overwrite working file, soft-delete newer versions.
+
+        Args:
+            version: Version number to revert to
+
+        Returns:
+            The snapshot filename that was restored
+
+        Raises:
+            ProjectError: If revert fails
+        """
+        if not self.current_project:
+            raise ProjectError("No project is currently open")
+
+        commit = self.get_commit_by_version(version)
+        if not commit:
+            raise ProjectError(f"Version {version} not found")
+
+        if commit.deleted:
+            raise ProjectError(f"Version {version} has been deleted")
+
+        # Load snapshot data
+        snapshot_data = self.load_version_data(version)
+        if snapshot_data is None:
+            raise ProjectError(f"Could not load snapshot for version {version}")
+
+        project_dir = Path(self.current_project.project_path)
+
+        # Overwrite working file
+        working_path = project_dir / self.current_project.working_rom
+        with open(working_path, "wb") as f:
+            f.write(snapshot_data)
+
+        # Soft-delete all versions newer than target
+        for c in self.commits:
+            if c.version > version and not c.deleted:
+                self.soft_delete_version(c.version)
+
+        # Append revert entry to tuning log
+        self._append_tuning_log_revert(version, commit)
+
+        snapshot_name = commit.snapshot_filename or f"v{version}"
+        logger.info(f"Reverted to version {version} ({snapshot_name})")
+        return snapshot_name
+
     def close_project(self):
         """Close the current project"""
         if self.current_project:
@@ -378,6 +467,147 @@ class ProjectManager:
     def is_project_open(self) -> bool:
         """Check if a project is currently open"""
         return self.current_project is not None
+
+    def _write_tuning_log_header(
+        self, project: Project, source_filename: str, checksum: str
+    ):
+        """Write initial TUNING_LOG.md header when creating a project"""
+        rom = project.original_rom
+        log_path = Path(project.project_path) / "TUNING_LOG.md"
+        date_str = project.created_at.strftime("%Y-%m-%d %H:%M")
+
+        header = (
+            f"# Tuning Log — {rom.rom_id}\n\n"
+            f"| | |\n"
+            f"|---|---|\n"
+            f"| **Vehicle** | {rom.make} {rom.model} |\n"
+            f"| **ECU** | {rom.rom_id} ({rom.definition_xmlid}) |\n"
+            f"| **Original ROM** | {source_filename} |\n"
+            f"| **Checksum** | {checksum[:16]}... |\n"
+            f"| **Created** | {date_str} |\n\n"
+            f"---\n"
+        )
+
+        with open(log_path, "w", encoding="utf-8") as f:
+            f.write(header)
+
+    def _append_tuning_log(self, commit: Commit):
+        """Append a version entry to TUNING_LOG.md"""
+        if not self.current_project:
+            return
+
+        log_path = Path(self.current_project.project_path) / "TUNING_LOG.md"
+
+        # Create the log file if it doesn't exist (backward compat for old projects)
+        if not log_path.exists():
+            rom = self.current_project.original_rom
+            checksum = rom.checksum_sha256
+            log_path.write_text(
+                f"# Tuning Log — {rom.rom_id}\n\n---\n",
+                encoding="utf-8",
+            )
+
+        # Find previous commit's snapshot filename
+        prev_commit = self.get_commit_by_version(commit.version - 1)
+        if prev_commit and prev_commit.snapshot_filename:
+            based_on = f"`{prev_commit.snapshot_filename}`"
+        elif commit.version == 1:
+            based_on = f"`{self.current_project.original_rom.filename}`"
+        else:
+            based_on = f"v{commit.version - 1}"
+
+        version_name = ""
+        if commit.snapshot_filename:
+            # Extract version_name from snapshot filename pattern: v{N}_{ROMID}_{name}.bin
+            parts = commit.snapshot_filename.rsplit(".bin", 1)[0]
+            rom_id = self.current_project.original_rom.rom_id
+            prefix = f"v{commit.version}_{rom_id}_"
+            if parts.startswith(prefix):
+                version_name = parts[len(prefix) :]
+
+        timestamp = commit.timestamp.strftime("%Y-%m-%d %H:%M")
+
+        # Build table summary
+        table_lines = []
+        for tc in commit.changes:
+            total = len(tc.cell_changes)
+            if total == 0:
+                continue
+
+            # Analyze direction
+            increases = sum(1 for c in tc.cell_changes if c.new_value > c.old_value)
+            decreases = sum(1 for c in tc.cell_changes if c.new_value < c.old_value)
+
+            if increases > 0 and decreases == 0:
+                # Calculate average % increase
+                pct_changes = [
+                    (c.new_value - c.old_value) / abs(c.old_value) * 100
+                    for c in tc.cell_changes
+                    if c.old_value != 0
+                ]
+                avg = sum(pct_changes) / len(pct_changes) if pct_changes else 0
+                direction = f"\u2191 avg +{avg:.1f}%"
+            elif decreases > 0 and increases == 0:
+                pct_changes = [
+                    (c.old_value - c.new_value) / abs(c.old_value) * 100
+                    for c in tc.cell_changes
+                    if c.old_value != 0
+                ]
+                avg = sum(pct_changes) / len(pct_changes) if pct_changes else 0
+                direction = f"\u2193 avg -{avg:.1f}%"
+            elif increases == 0 and decreases == 0:
+                # All set to same value
+                val = tc.cell_changes[0].new_value
+                direction = f"\u2192 set to {val}"
+            else:
+                direction = "\u223c mixed"
+
+            table_lines.append(f"| {tc.table_name} | {total} | {direction} |")
+
+        table_section = ""
+        if table_lines:
+            table_section = (
+                "\n| Table | Cells Changed | Direction |\n"
+                "|-------|--------------|----------|\n" + "\n".join(table_lines) + "\n"
+            )
+
+        entry = (
+            f"\n## v{commit.version} \u2014 {version_name} ({timestamp})\n\n"
+            f"Based on: {based_on}\n"
+        )
+
+        if commit.message:
+            entry += f"\n{commit.message}\n"
+
+        entry += table_section
+
+        if commit.snapshot_filename:
+            entry += f"\n**ROM file:** `{commit.snapshot_filename}`\n"
+
+        entry += "\n### Results\n<!-- Fill in after testing -->\n\n---\n"
+
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(entry)
+
+    def _append_tuning_log_revert(self, version: int, commit: Commit):
+        """Append a revert entry to TUNING_LOG.md"""
+        if not self.current_project:
+            return
+
+        log_path = Path(self.current_project.project_path) / "TUNING_LOG.md"
+        if not log_path.exists():
+            return
+
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
+        snapshot_name = commit.snapshot_filename or f"v{version}"
+
+        entry = (
+            f"\n## Reverted to v{version} ({timestamp})\n\n"
+            f"Restored working ROM from `{snapshot_name}`\n\n---\n"
+        )
+
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(entry)
 
     def _save_project_file(self, project: Project):
         """Save project.json (atomic write)"""

--- a/src/core/version_models.py
+++ b/src/core/version_models.py
@@ -12,8 +12,9 @@ Serialization Pattern:
 """
 
 from dataclasses import dataclass, field
+import os
 from pathlib import Path
-from typing import Optional, List, Dict, Any, Protocol, TypeVar, runtime_checkable
+from typing import Optional, List, Protocol, TypeVar, runtime_checkable
 from datetime import datetime
 import uuid
 
@@ -114,6 +115,7 @@ class Commit:
     changes: List[TableChanges]
     has_snapshot: bool = False
     snapshot_filename: Optional[str] = None  # Custom filename like v1_LF9VEB_stage1.bin
+    deleted: bool = False  # Soft-deleted version (moved to _trash/)
 
     @classmethod
     def create(
@@ -122,10 +124,15 @@ class Commit:
         changes: List[TableChanges],
         version: int = 0,
         parent_id: Optional[str] = None,
-        author: str = "User",
+        author: Optional[str] = None,
         snapshot_filename: Optional[str] = None,
     ) -> "Commit":
         """Factory method to create a new commit"""
+        if author is None:
+            try:
+                author = os.getlogin()
+            except OSError:
+                author = "User"
         return cls(
             id=uuid.uuid4().hex,
             version=version,
@@ -151,6 +158,7 @@ class Commit:
             "changes": [c.to_dict() for c in self.changes],
             "has_snapshot": self.has_snapshot,
             "snapshot_filename": self.snapshot_filename,
+            "deleted": self.deleted,
         }
 
     @classmethod
@@ -173,6 +181,7 @@ class Commit:
             changes=[TableChanges.from_dict(c) for c in data["changes"]],
             has_snapshot=data.get("has_snapshot", False),
             snapshot_filename=data.get("snapshot_filename"),  # Backward compatibility
+            deleted=data.get("deleted", False),  # Backward compatibility
         )
 
 
@@ -302,8 +311,6 @@ class Project:
     head_commit_id: Optional[str]
     project_path: str  # Path to project folder
     head_version: int = 0  # Current version number
-    last_suffix: str = ""  # Last user-entered suffix for filename suggestions
-    settings: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict:
         return {
@@ -316,8 +323,6 @@ class Project:
             "working_rom": self.working_rom,
             "head_commit_id": self.head_commit_id,
             "head_version": self.head_version,
-            "last_suffix": self.last_suffix,
-            "settings": self.settings,
         }
 
     @classmethod
@@ -333,8 +338,6 @@ class Project:
             head_commit_id=data.get("head_commit_id"),
             project_path=project_path,
             head_version=data.get("head_version", 0),  # Backward compatibility
-            last_suffix=data.get("last_suffix", ""),  # Backward compatibility
-            settings=data.get("settings", {}),
         )
 
     @property

--- a/src/ui/commit_dialog.py
+++ b/src/ui/commit_dialog.py
@@ -1,8 +1,11 @@
 """
 Commit Dialog
 
-Dialog for entering commit message when saving changes.
+Dialog for entering commit details when saving a version.
+Every commit creates a named ROM snapshot.
 """
+
+import re
 
 from PySide6.QtWidgets import (
     QDialog,
@@ -13,7 +16,6 @@ from PySide6.QtWidgets import (
     QDialogButtonBox,
     QListWidget,
     QGroupBox,
-    QCheckBox,
     QLineEdit,
 )
 from typing import List
@@ -22,27 +24,24 @@ from ..core.version_models import TableChanges
 
 
 class CommitDialog(QDialog):
-    """Dialog for committing changes with a message"""
+    """Dialog for committing changes with a mandatory version name"""
 
     def __init__(
         self,
         pending_changes: List[TableChanges],
         next_version: int = 1,
         rom_id: str = "",
-        suggested_suffix: str = "",
         parent=None,
     ):
         super().__init__(parent)
-        self.setWindowTitle("Save Changes")
+        self.setWindowTitle("Save Version")
         self.setMinimumSize(500, 450)
 
         self.pending_changes = pending_changes
         self.next_version = next_version
         self.rom_id = rom_id
-        self.suggested_suffix = suggested_suffix
-        self.commit_message = ""
-        self.create_snapshot = False
-        self.snapshot_suffix = ""
+        self._version_name = ""
+        self._commit_message = ""
 
         self._init_ui()
 
@@ -55,8 +54,25 @@ class CommitDialog(QDialog):
         version_label.setStyleSheet("font-size: 14px; padding: 5px;")
         layout.addWidget(version_label)
 
-        # Commit message (prominent, at top)
-        msg_group = QGroupBox("Commit Message (required)")
+        # Version name (required)
+        name_group = QGroupBox("Version Name (required)")
+        name_layout = QVBoxLayout()
+        name_group.setLayout(name_layout)
+
+        self.name_edit = QLineEdit()
+        self.name_edit.setPlaceholderText("e.g., egr_delete, stage1, fuel_wot_richen")
+        self.name_edit.textChanged.connect(self._update_filename_preview)
+        name_layout.addWidget(self.name_edit)
+
+        # Filename preview
+        self.filename_preview = QLabel()
+        self.filename_preview.setStyleSheet("color: gray; font-style: italic;")
+        name_layout.addWidget(self.filename_preview)
+
+        layout.addWidget(name_group)
+
+        # Commit message (optional)
+        msg_group = QGroupBox("Description (optional)")
         msg_layout = QVBoxLayout()
         msg_group.setLayout(msg_layout)
 
@@ -68,12 +84,12 @@ class CommitDialog(QDialog):
             "- Adjusted timing for 91 octane fuel\n"
             "- Disabled closed-loop fuel correction"
         )
-        self.message_edit.setMinimumHeight(100)
+        self.message_edit.setMinimumHeight(80)
         msg_layout.addWidget(self.message_edit)
 
         layout.addWidget(msg_group)
 
-        # Modified tables list (simple, no cell details)
+        # Modified tables list (read-only, informational)
         tables_group = QGroupBox(f"Modified Tables ({len(self.pending_changes)})")
         tables_layout = QVBoxLayout()
         tables_group.setLayout(tables_layout)
@@ -87,154 +103,58 @@ class CommitDialog(QDialog):
         tables_layout.addWidget(self.tables_list)
         layout.addWidget(tables_group)
 
-        # Snapshot section
-        snapshot_group = QGroupBox("ROM Snapshot")
-        snapshot_layout = QVBoxLayout()
-        snapshot_group.setLayout(snapshot_layout)
-
-        self.snapshot_checkbox = QCheckBox(
-            "Save ROM snapshot (recommended for major changes)"
-        )
-        self.snapshot_checkbox.setToolTip(
-            "Creates a full copy of the ROM at this version.\n"
-            "Allows you to revert to this exact state later."
-        )
-        self.snapshot_checkbox.toggled.connect(self._on_snapshot_toggled)
-        snapshot_layout.addWidget(self.snapshot_checkbox)
-
-        # Suffix input (only enabled when snapshot checked)
-        suffix_layout = QHBoxLayout()
-        suffix_label = QLabel("Filename suffix:")
-        suffix_layout.addWidget(suffix_label)
-
-        self.suffix_edit = QLineEdit()
-        self.suffix_edit.setPlaceholderText("e.g., timing_fix, stage1, fuel_tune")
-        self.suffix_edit.setText(self.suggested_suffix)
-        self.suffix_edit.setEnabled(False)
-        self.suffix_edit.textChanged.connect(self._update_filename_preview)
-        suffix_layout.addWidget(self.suffix_edit)
-
-        snapshot_layout.addLayout(suffix_layout)
-
-        # Filename preview
-        self.filename_preview = QLabel()
-        self.filename_preview.setStyleSheet("color: gray; font-style: italic;")
-        self._update_filename_preview()
-        snapshot_layout.addWidget(self.filename_preview)
-
-        layout.addWidget(snapshot_group)
-
         # Spacer
         layout.addStretch()
 
         # Buttons
         button_box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
-        button_box.button(QDialogButtonBox.Ok).setText("Commit")
+        self.ok_button = button_box.button(QDialogButtonBox.Ok)
+        self.ok_button.setText("Commit")
+        self.ok_button.setEnabled(False)
         button_box.accepted.connect(self._on_accept)
         button_box.rejected.connect(self.reject)
         layout.addWidget(button_box)
 
-    def _on_snapshot_toggled(self, checked: bool):
-        """Handle snapshot checkbox toggle"""
-        self.suffix_edit.setEnabled(checked)
+        # Set initial preview text (must be after ok_button is created)
         self._update_filename_preview()
 
+    @staticmethod
+    def _sanitize_name(text: str) -> str:
+        """Sanitize version name: lowercase, spaces to underscores, strip special chars"""
+        text = text.strip().lower()
+        text = text.replace(" ", "_")
+        text = re.sub(r"[^a-z0-9_]", "", text)
+        return text
+
     def _update_filename_preview(self):
-        """Update the filename preview label"""
-        if self.snapshot_checkbox.isChecked():
-            suffix = self.suffix_edit.text().strip()
-            if suffix:
-                filename = f"v{self.next_version}_{self.rom_id}_{suffix}.bin"
-                self.filename_preview.setText(f"File: {filename}")
-            else:
-                self.filename_preview.setText("Enter a suffix for the filename")
+        """Update the filename preview label and OK button state"""
+        raw = self.name_edit.text()
+        sanitized = self._sanitize_name(raw)
+
+        if sanitized:
+            filename = f"v{self.next_version}_{self.rom_id}_{sanitized}.bin"
+            self.filename_preview.setText(f"File: {filename}")
+            self.ok_button.setEnabled(True)
         else:
-            self.filename_preview.setText("No snapshot will be created")
+            self.filename_preview.setText("Enter a version name")
+            self.ok_button.setEnabled(False)
 
     def _on_accept(self):
         """Validate and accept"""
-        # Validate message
-        message = self.message_edit.toPlainText().strip()
-        if not message:
-            self.message_edit.setFocus()
-            self.message_edit.setStyleSheet("border: 2px solid red;")
+        sanitized = self._sanitize_name(self.name_edit.text())
+        if not sanitized:
+            self.name_edit.setFocus()
+            self.name_edit.setStyleSheet("border: 2px solid red;")
             return
 
-        # Validate suffix if snapshot is checked
-        if self.snapshot_checkbox.isChecked():
-            suffix = self.suffix_edit.text().strip()
-            if not suffix:
-                self.suffix_edit.setFocus()
-                self.suffix_edit.setStyleSheet("border: 2px solid red;")
-                return
-            self.snapshot_suffix = suffix
-
-        self.commit_message = message
-        self.create_snapshot = self.snapshot_checkbox.isChecked()
+        self._version_name = sanitized
+        self._commit_message = self.message_edit.toPlainText().strip()
         self.accept()
+
+    def get_version_name(self) -> str:
+        """Get the sanitized version name"""
+        return self._version_name
 
     def get_commit_message(self) -> str:
         """Get the commit message"""
-        return self.commit_message
-
-    def get_create_snapshot(self) -> bool:
-        """Get whether to create a snapshot"""
-        return self.create_snapshot
-
-    def get_snapshot_suffix(self) -> str:
-        """Get the user-entered snapshot suffix"""
-        return self.snapshot_suffix
-
-
-class QuickCommitDialog(QDialog):
-    """Simplified commit dialog for quick saves"""
-
-    def __init__(self, tables_modified: List[str], parent=None):
-        super().__init__(parent)
-        self.setWindowTitle("Quick Commit")
-        self.setMinimumSize(400, 200)
-
-        self.tables_modified = tables_modified
-        self.commit_message = ""
-
-        self._init_ui()
-
-    def _init_ui(self):
-        layout = QVBoxLayout()
-        self.setLayout(layout)
-
-        # Tables summary
-        tables_str = ", ".join(self.tables_modified[:3])
-        if len(self.tables_modified) > 3:
-            tables_str += f" (+{len(self.tables_modified) - 3} more)"
-
-        summary = QLabel(f"Modified: <b>{tables_str}</b>")
-        summary.setWordWrap(True)
-        layout.addWidget(summary)
-
-        # Commit message
-        layout.addWidget(QLabel("Commit Message:"))
-        self.message_edit = QTextEdit()
-        self.message_edit.setPlaceholderText("What did you change?")
-        self.message_edit.setMaximumHeight(80)
-        layout.addWidget(self.message_edit)
-
-        # Buttons
-        button_box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
-        button_box.button(QDialogButtonBox.Ok).setText("Commit")
-        button_box.accepted.connect(self._on_accept)
-        button_box.rejected.connect(self.reject)
-        layout.addWidget(button_box)
-
-    def _on_accept(self):
-        """Validate and accept"""
-        message = self.message_edit.toPlainText().strip()
-        if not message:
-            self.message_edit.setFocus()
-            return
-
-        self.commit_message = message
-        self.accept()
-
-    def get_commit_message(self) -> str:
-        return self.commit_message
+        return self._commit_message

--- a/src/ui/compare_window.py
+++ b/src/ui/compare_window.py
@@ -27,7 +27,7 @@ from PySide6.QtWidgets import (
     QStyledItemDelegate,
     QMessageBox,
 )
-from PySide6.QtCore import Qt, QSize
+from PySide6.QtCore import Qt, QSettings, QSize
 from PySide6.QtGui import (
     QColor,
     QBrush,
@@ -140,6 +140,7 @@ class CompareWindow(QMainWindow):
         name_a: str,
         name_b: str,
         parent=None,
+        readonly: bool = False,
     ):
         super().__init__(parent)
         self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
@@ -152,6 +153,7 @@ class CompareWindow(QMainWindow):
         self._color_b = color_b
         self._name_a = name_a
         self._name_b = name_b
+        self._readonly = readonly
         self._cross_def = definition_a.romid.xmlid != definition_b.romid.xmlid
         self._changed_only = False
         self._syncing_scroll = False
@@ -694,7 +696,7 @@ class CompareWindow(QMainWindow):
         self._table_right.setItemDelegate(_CompareCellDelegate(self._table_right))
         right_layout.addWidget(self._table_right)
 
-        # Center column with copy buttons
+        # Center column with copy buttons (hidden in readonly mode)
         center_col = QWidget()
         center_layout = QVBoxLayout(center_col)
         center_layout.setContentsMargins(2, 0, 2, 0)
@@ -731,7 +733,12 @@ class CompareWindow(QMainWindow):
         center_layout.addWidget(self._copy_b_to_a_btn)
 
         center_layout.addStretch()
-        center_col.setFixedWidth(32)
+
+        if self._readonly:
+            center_col.setVisible(False)
+            center_col.setFixedWidth(0)
+        else:
+            center_col.setFixedWidth(32)
 
         self._table_splitter.addWidget(left_panel)
         self._table_splitter.addWidget(center_col)
@@ -904,7 +911,7 @@ class CompareWindow(QMainWindow):
 
     def _update_copy_buttons(self):
         """Enable/disable copy buttons based on current table entry."""
-        if self._current_index < 0:
+        if self._readonly or self._current_index < 0:
             self._copy_a_to_b_btn.setEnabled(False)
             self._copy_b_to_a_btn.setEnabled(False)
             return
@@ -1426,7 +1433,12 @@ class CompareWindow(QMainWindow):
     # ========== Window Sizing ==========
 
     def _auto_size(self):
-        """Size the window to fit the content, up to screen limits."""
+        """Size the window to fit the content, or restore saved geometry."""
+        settings = QSettings()
+        geometry = settings.value("ui/compare_window_geometry")
+        if geometry:
+            self.restoreGeometry(geometry)
+            return
         screen = QApplication.primaryScreen()
         if screen:
             avail = screen.availableGeometry()
@@ -1440,7 +1452,9 @@ class CompareWindow(QMainWindow):
         self.resize(min(1200, max_w), min(700, max_h))
 
     def closeEvent(self, event):
-        """Clean up on close."""
+        """Save geometry and clean up on close."""
+        settings = QSettings()
+        settings.setValue("ui/compare_window_geometry", self.saveGeometry())
         parent = self.parent()
         if parent and hasattr(parent, "compare_window"):
             parent.compare_window = None

--- a/src/ui/history_viewer.py
+++ b/src/ui/history_viewer.py
@@ -1,7 +1,7 @@
 """
 History Viewer Widget
 
-Displays commit history with ability to view details.
+Displays commit history with ability to view details, revert, and delete versions.
 """
 
 from PySide6.QtWidgets import (
@@ -19,8 +19,10 @@ from PySide6.QtWidgets import (
     QDialog,
     QPushButton,
     QLineEdit,
+    QCheckBox,
 )
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Qt, QSettings, Signal
+from PySide6.QtGui import QColor, QFont
 
 from ..core.version_models import Commit
 from ..core.project_manager import ProjectManager
@@ -31,6 +33,8 @@ class HistoryViewer(QDialog):
 
     commit_selected = Signal(str)  # Emits commit ID
     view_table_diff = Signal(str, object)  # Emits (table_name, Commit)
+    revert_requested = Signal(int)  # Emits version number
+    delete_requested = Signal(int)  # Emits version number
 
     def __init__(self, project_manager: ProjectManager, parent=None):
         super().__init__(parent)
@@ -38,24 +42,30 @@ class HistoryViewer(QDialog):
         self.setWindowTitle("Version History")
         self.setMinimumSize(900, 600)
         self._init_ui()
+        self._restore_geometry()
         self.refresh()
 
     def _init_ui(self):
         layout = QVBoxLayout()
         self.setLayout(layout)
 
-        # Search bar
-        search_layout = QHBoxLayout()
-        search_layout.addWidget(QLabel("Search:"))
+        # Top bar: search + show deleted toggle
+        top_layout = QHBoxLayout()
+        top_layout.addWidget(QLabel("Search:"))
         self.search_edit = QLineEdit()
         self.search_edit.setPlaceholderText("Filter by message or table name...")
         self.search_edit.textChanged.connect(self._filter_commits)
-        search_layout.addWidget(self.search_edit)
-        layout.addLayout(search_layout)
+        top_layout.addWidget(self.search_edit)
+
+        self.show_deleted_cb = QCheckBox("Show deleted")
+        self.show_deleted_cb.toggled.connect(self.refresh)
+        top_layout.addWidget(self.show_deleted_cb)
+
+        layout.addLayout(top_layout)
 
         # Splitter for list and details
-        splitter = QSplitter(Qt.Horizontal)
-        layout.addWidget(splitter)
+        self._splitter = QSplitter(Qt.Horizontal)
+        layout.addWidget(self._splitter)
 
         # Left: Commit list
         left_widget = QWidget()
@@ -66,15 +76,14 @@ class HistoryViewer(QDialog):
         left_layout.addWidget(QLabel("<b>Versions</b> (newest first)"))
 
         self.commit_tree = QTreeWidget()
-        self.commit_tree.setHeaderLabels(["Version", "Message", "Date", "Tables"])
-        self.commit_tree.setColumnWidth(0, 60)
-        self.commit_tree.setColumnWidth(1, 200)
-        self.commit_tree.setColumnWidth(2, 100)
+        self.commit_tree.setHeaderLabels(["Snapshot", "Date", "Tables"])
+        self.commit_tree.setColumnWidth(0, 260)
+        self.commit_tree.setColumnWidth(1, 120)
         self.commit_tree.setRootIsDecorated(False)
         self.commit_tree.itemClicked.connect(self._on_commit_selected)
         left_layout.addWidget(self.commit_tree)
 
-        splitter.addWidget(left_widget)
+        self._splitter.addWidget(left_widget)
 
         # Right: Commit details
         right_widget = QWidget()
@@ -87,10 +96,12 @@ class HistoryViewer(QDialog):
         # Details area
         self.details_widget = CommitDetailsWidget()
         self.details_widget.view_table_requested.connect(self._on_view_table_requested)
+        self.details_widget.revert_requested.connect(self._on_revert_requested)
+        self.details_widget.delete_requested.connect(self._on_delete_requested)
         right_layout.addWidget(self.details_widget)
 
-        splitter.addWidget(right_widget)
-        splitter.setSizes([400, 500])
+        self._splitter.addWidget(right_widget)
+        self._splitter.setSizes([400, 500])
 
         # Close button
         button_layout = QHBoxLayout()
@@ -100,19 +111,46 @@ class HistoryViewer(QDialog):
         button_layout.addWidget(close_btn)
         layout.addLayout(button_layout)
 
+    def _restore_geometry(self):
+        """Restore window size, splitter, and column widths from settings"""
+        settings = QSettings()
+        geometry = settings.value("ui/history_viewer_geometry")
+        if geometry:
+            self.restoreGeometry(geometry)
+        splitter_state = settings.value("ui/history_viewer_splitter")
+        if splitter_state:
+            self._splitter.restoreState(splitter_state)
+        header_state = settings.value("ui/history_viewer_header")
+        if header_state:
+            self.commit_tree.header().restoreState(header_state)
+
+    def done(self, result):
+        """Save layout state when dialog closes (accept, reject, or X button)"""
+        settings = QSettings()
+        settings.setValue("ui/history_viewer_geometry", self.saveGeometry())
+        settings.setValue("ui/history_viewer_splitter", self._splitter.saveState())
+        settings.setValue(
+            "ui/history_viewer_header", self.commit_tree.header().saveState()
+        )
+        super().done(result)
+
     def refresh(self):
         """Reload commit history"""
         self.commit_tree.clear()
         self.details_widget.clear()
 
+        show_deleted = self.show_deleted_cb.isChecked()
         commits = self.project_manager.get_recent_commits(100)
 
         for commit in commits:
+            if commit.deleted and not show_deleted:
+                continue
             self._add_commit_item(commit)
 
     def _add_commit_item(self, commit: Commit):
         """Add a commit to the tree"""
-        version_str = f"v{commit.version}"
+        # Use snapshot filename as primary display (includes version + name)
+        snapshot = commit.snapshot_filename or f"v{commit.version}"
         date_str = commit.timestamp.strftime("%Y-%m-%d %H:%M")
 
         tables_count = len(commit.tables_modified)
@@ -121,20 +159,25 @@ class HistoryViewer(QDialog):
         else:
             tables_str = str(tables_count)
 
-        # Truncate message for display
-        msg = commit.message.split("\n")[0]  # First line only
-        if len(msg) > 35:
-            msg = msg[:32] + "..."
-
-        item = QTreeWidgetItem([version_str, msg, date_str, tables_str])
+        num_cols = 3
+        item = QTreeWidgetItem([snapshot, date_str, tables_str])
         item.setData(0, Qt.UserRole, commit.id)
         item.setData(0, Qt.UserRole + 1, commit)  # Store commit object
-        item.setToolTip(1, commit.message)
+        item.setToolTip(0, commit.message or snapshot)
 
         # Style initial commit (v0) differently
         if commit.version == 0:
-            for col in range(4):
+            for col in range(num_cols):
                 item.setForeground(col, Qt.gray)
+
+        # Style deleted commits with gray + strikethrough
+        if commit.deleted:
+            deleted_color = QColor(160, 160, 160)
+            strikethrough_font = QFont()
+            strikethrough_font.setStrikeOut(True)
+            for col in range(num_cols):
+                item.setForeground(col, deleted_color)
+                item.setFont(col, strikethrough_font)
 
         self.commit_tree.addTopLevelItem(item)
 
@@ -143,6 +186,16 @@ class HistoryViewer(QDialog):
         commit = self.details_widget.current_commit
         if commit:
             self.view_table_diff.emit(table_name, commit)
+
+    def _on_revert_requested(self, version: int):
+        """Forward revert request"""
+        self.revert_requested.emit(version)
+        self.refresh()
+
+    def _on_delete_requested(self, version: int):
+        """Forward delete request"""
+        self.delete_requested.emit(version)
+        self.refresh()
 
     def _filter_commits(self, text: str):
         """Filter commits by search text using stored item data"""
@@ -173,6 +226,8 @@ class CommitDetailsWidget(QWidget):
     """Shows detailed information about a single commit"""
 
     view_table_requested = Signal(str)  # Emits table name
+    revert_requested = Signal(int)  # Emits version number
+    delete_requested = Signal(int)  # Emits version number
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -209,13 +264,29 @@ class CommitDetailsWidget(QWidget):
         # View button
         view_btn_layout = QHBoxLayout()
         view_btn_layout.addStretch()
-        self.view_diff_btn = QPushButton("View Table Changes...")
+        self.view_diff_btn = QPushButton("Compare Versions...")
         self.view_diff_btn.setEnabled(False)
         self.view_diff_btn.clicked.connect(self._on_view_diff_clicked)
         view_btn_layout.addWidget(self.view_diff_btn)
         tables_layout.addLayout(view_btn_layout)
 
         layout.addWidget(tables_group)
+
+        # Action buttons
+        action_layout = QHBoxLayout()
+
+        self.revert_btn = QPushButton("Revert to this version")
+        self.revert_btn.setEnabled(False)
+        self.revert_btn.clicked.connect(self._on_revert_clicked)
+        action_layout.addWidget(self.revert_btn)
+
+        self.delete_btn = QPushButton("Delete this version")
+        self.delete_btn.setEnabled(False)
+        self.delete_btn.clicked.connect(self._on_delete_clicked)
+        action_layout.addWidget(self.delete_btn)
+
+        action_layout.addStretch()
+        layout.addLayout(action_layout)
 
         # Help text
         help_label = QLabel("Double-click a table to view changes")
@@ -228,13 +299,14 @@ class CommitDetailsWidget(QWidget):
 
         # Show info with version number
         snapshot_str = commit.snapshot_filename if commit.snapshot_filename else "No"
+        deleted_str = " <b style='color:red'>(DELETED)</b>" if commit.deleted else ""
         info = (
-            f"<b>Version:</b> v{commit.version}<br>"
+            f"<b>Version:</b> v{commit.version}{deleted_str}<br>"
             f"<b>Date:</b> {commit.timestamp.strftime('%Y-%m-%d %H:%M:%S')}<br>"
             f"<b>Author:</b> {commit.author}<br>"
             f"<b>Snapshot:</b> {snapshot_str}<br>"
             f"<hr>"
-            f"<b>Message:</b><br>{commit.message}"
+            f"<b>Message:</b><br>{commit.message.replace(chr(10), '<br>')}"
         )
         self.info_text.setHtml(info)
 
@@ -259,7 +331,12 @@ class CommitDetailsWidget(QWidget):
                 item.setData(Qt.UserRole, table_name)
                 self.tables_list.addItem(item)
 
-            self.view_diff_btn.setEnabled(True)
+            self.view_diff_btn.setEnabled(not commit.deleted)
+
+        # Enable/disable action buttons
+        is_actionable = commit.version > 0 and not commit.deleted
+        self.revert_btn.setEnabled(is_actionable)
+        self.delete_btn.setEnabled(is_actionable)
 
     def _on_table_double_clicked(self, item: QListWidgetItem):
         """Handle double-click on table"""
@@ -268,12 +345,24 @@ class CommitDetailsWidget(QWidget):
             self.view_table_requested.emit(table_name)
 
     def _on_view_diff_clicked(self):
-        """Handle view diff button click"""
+        """Handle view diff button click — uses selected table or first table"""
         current_item = self.tables_list.currentItem()
+        if not current_item and self.tables_list.count() > 0:
+            current_item = self.tables_list.item(0)
         if current_item:
             table_name = current_item.data(Qt.UserRole)
             if table_name:
                 self.view_table_requested.emit(table_name)
+
+    def _on_revert_clicked(self):
+        """Handle revert button click"""
+        if self.current_commit and self.current_commit.version > 0:
+            self.revert_requested.emit(self.current_commit.version)
+
+    def _on_delete_clicked(self):
+        """Handle delete button click"""
+        if self.current_commit and self.current_commit.version > 0:
+            self.delete_requested.emit(self.current_commit.version)
 
     def clear(self):
         """Clear the details view"""
@@ -281,6 +370,8 @@ class CommitDetailsWidget(QWidget):
         self.tables_list.clear()
         self.current_commit = None
         self.view_diff_btn.setEnabled(False)
+        self.revert_btn.setEnabled(False)
+        self.delete_btn.setEnabled(False)
 
 
 class HistoryPanel(QWidget):
@@ -316,6 +407,9 @@ class HistoryPanel(QWidget):
         commits = self.project_manager.get_recent_commits(10)
 
         for commit in commits:
+            if commit.deleted:
+                continue
+
             date_str = commit.timestamp.strftime("%m/%d %H:%M")
             msg = commit.message.split("\n")[0][:25]
 

--- a/src/ui/project_mixin.py
+++ b/src/ui/project_mixin.py
@@ -16,8 +16,12 @@ This is a mixin class — it has no __init__ and relies on MainWindow providing:
 - self.statusBar() method
 """
 
+import tempfile
+import os
 from pathlib import Path
 
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor
 from PySide6.QtWidgets import QDialog, QMessageBox
 
 from src.utils.logging_config import get_logger
@@ -28,8 +32,8 @@ from src.core.project_manager import ProjectManager
 from src.ui.rom_document import RomDocument
 from src.ui.project_wizard import ProjectWizard
 from src.ui.commit_dialog import CommitDialog
+from src.ui.compare_window import CompareWindow
 from src.ui.history_viewer import HistoryViewer
-from src.ui.table_viewer_window import TableViewerWindow
 
 logger = get_logger(__name__)
 
@@ -177,37 +181,35 @@ class ProjectMixin:
         # Get version info for dialog
         next_version = self.project_manager.get_next_version()
         rom_id = self.project_manager.current_project.original_rom.rom_id
-        suggested_suffix = self.project_manager.current_project.last_suffix
 
         # Show commit dialog with version info
         dialog = CommitDialog(
             pending,
             next_version=next_version,
             rom_id=rom_id,
-            suggested_suffix=suggested_suffix,
             parent=self,
         )
         if dialog.exec() == QDialog.Accepted:
             try:
                 message = dialog.get_commit_message()
-                create_snapshot = dialog.get_create_snapshot()
-                snapshot_suffix = dialog.get_snapshot_suffix()
+                version_name = dialog.get_version_name()
 
                 # Save changes to working ROM file first
                 document = self.get_current_document()
                 if document:
                     document.rom_reader.save_rom()
 
-                # Create commit with version numbering
+                # Create commit with version numbering (always creates snapshot)
                 commit = self.project_manager.commit_changes(
                     message=message,
                     changes=pending,
-                    create_snapshot=create_snapshot,
-                    snapshot_suffix=snapshot_suffix,
+                    version_name=version_name,
                 )
 
-                # Clear pending changes
+                # Clear pending changes and modified flag
                 self.change_tracker.clear_pending_changes()
+                if document:
+                    document.set_modified(False)
 
                 # Update UI
                 self._update_project_ui()
@@ -235,34 +237,45 @@ class ProjectMixin:
             )
             return
 
-        dialog = HistoryViewer(self.project_manager, self)
-        dialog.view_table_diff.connect(self._on_view_table_diff)
-        dialog.exec()
+        self._history_dialog = HistoryViewer(self.project_manager, self)
+        self._history_dialog.view_table_diff.connect(self._on_view_table_diff)
+        self._history_dialog.revert_requested.connect(self._on_revert_version)
+        self._history_dialog.delete_requested.connect(self._on_delete_version)
+        self._history_dialog.exec()
+        self._history_dialog = None
 
     def _on_view_table_diff(self, table_name: str, commit):
         """
-        Open a table viewer showing changes from a specific commit
+        Open a read-only CompareWindow showing changes from a specific commit.
+
+        Uses the base version (commit.version - 1) vs the commit version,
+        displayed in the ROM comparison view with copy buttons disabled.
+        Only one compare window is open at a time — opening a new one closes the previous.
 
         Args:
-            table_name: Name of the table to view
+            table_name: Name of the table to view (used for context, all tables shown)
             commit: Commit object containing the changes
         """
         document = self.get_current_document()
         if not document:
             return
 
-        # Find the table definition
-        table = document.rom_definition.get_table_by_name(table_name)
-        if not table:
-            QMessageBox.warning(
-                self, "Table Not Found", f"Could not find table: {table_name}"
-            )
-            return
+        # Close any existing version compare window
+        dialog = getattr(self, "_history_dialog", None)
+        if dialog:
+            old_cmp = getattr(dialog, "_compare_window", None)
+            if old_cmp is not None:
+                try:
+                    old_cmp.close()
+                except RuntimeError:
+                    pass  # C++ object already deleted
+                dialog._compare_window = None
 
         try:
             # Load base version data (previous version)
             base_version = commit.version - 1 if commit.version > 0 else 0
             base_rom_data = self.project_manager.load_version_data(base_version)
+            commit_rom_data = self.project_manager.load_version_data(commit.version)
 
             if base_rom_data is None:
                 QMessageBox.warning(
@@ -272,38 +285,95 @@ class ProjectMixin:
                 )
                 return
 
-            # Create a temporary RomReader to read base version table data
-            import tempfile
-            import os
+            if commit_rom_data is None:
+                QMessageBox.warning(
+                    self,
+                    "Version Not Found",
+                    f"Could not load version {commit.version} data.",
+                )
+                return
 
-            # Write base ROM to temp file and read table data
-            with tempfile.NamedTemporaryFile(delete=False, suffix=".bin") as tmp:
-                tmp.write(base_rom_data)
-                tmp_path = tmp.name
+            # Write both versions to temp files for RomReader
+            base_tmp = tempfile.NamedTemporaryFile(
+                delete=False, suffix=".bin", prefix="base_"
+            )
+            base_tmp.write(base_rom_data)
+            base_tmp.close()
+
+            commit_tmp = tempfile.NamedTemporaryFile(
+                delete=False, suffix=".bin", prefix="commit_"
+            )
+            commit_tmp.write(commit_rom_data)
+            commit_tmp.close()
 
             try:
-                base_reader = RomReader(tmp_path, document.rom_definition)
-                base_data = base_reader.read_table_data(table)
-            finally:
-                os.unlink(tmp_path)
+                base_reader = RomReader(base_tmp.name, document.rom_definition)
+                commit_reader = RomReader(commit_tmp.name, document.rom_definition)
+            except Exception:
+                os.unlink(base_tmp.name)
+                os.unlink(commit_tmp.name)
+                raise
 
-            # Read current version table data
-            current_data = document.rom_reader.read_table_data(table)
+            # Build version labels
+            base_commit = self.project_manager.get_commit_by_version(base_version)
+            base_name = (
+                base_commit.snapshot_filename
+                if base_commit and base_commit.snapshot_filename
+                else f"v{base_version}"
+            )
+            commit_name = (
+                commit.snapshot_filename
+                if commit.snapshot_filename
+                else f"v{commit.version}"
+            )
 
-            # Open diff viewer
-            viewer_window = TableViewerWindow(
-                table,
-                current_data,
+            # Open read-only compare window, parented to the history dialog
+            # so it appears on top of the modal dialog
+            parent_widget = dialog if dialog else self
+            window = CompareWindow(
+                base_reader,
+                commit_reader,
                 document.rom_definition,
-                rom_path=document.rom_path,
-                parent=self,
-                diff_mode=True,
-                diff_base_data=base_data,
+                document.rom_definition,
+                QColor(100, 100, 100),
+                QColor(100, 100, 100),
+                base_name,
+                commit_name,
+                parent=parent_widget,
+                readonly=True,
             )
-            viewer_window.setWindowTitle(
-                f"{table_name} (v{base_version} -> v{commit.version})"
-            )
-            viewer_window.show()
+
+            if not window.has_diffs:
+                window.deleteLater()
+                QMessageBox.information(
+                    self,
+                    "No Differences",
+                    f"No table differences found between v{base_version} and v{commit.version}.",
+                )
+                os.unlink(base_tmp.name)
+                os.unlink(commit_tmp.name)
+                return
+
+            # Clean up temp files when the window closes
+            def _cleanup():
+                try:
+                    os.unlink(base_tmp.name)
+                except OSError:
+                    pass
+                try:
+                    os.unlink(commit_tmp.name)
+                except OSError:
+                    pass
+
+            window.destroyed.connect(_cleanup)
+
+            # Track single instance on the dialog
+            if dialog:
+                dialog._compare_window = window
+
+            window.show()
+            window.raise_()
+            window.activateWindow()
 
         except RomEditorError as e:
             logger.error(f"Failed to open diff view: {e}")
@@ -317,3 +387,80 @@ class ProjectMixin:
                 "Error",
                 f"Unexpected error opening diff view:\n{type(e).__name__}: {e}",
             )
+
+    def _on_revert_version(self, version: int):
+        """Confirm and revert working ROM to a previous version"""
+        commit = self.project_manager.get_commit_by_version(version)
+        if not commit:
+            return
+
+        snapshot_name = commit.snapshot_filename or f"v{version}"
+        reply = QMessageBox.question(
+            self,
+            "Revert to Version",
+            f"Revert working ROM to v{version} ({snapshot_name})?\n\n"
+            f"This will:\n"
+            f"- Overwrite the current working ROM\n"
+            f"- Move all newer versions to trash\n\n"
+            f"This cannot be easily undone.",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+
+        if reply == QMessageBox.Yes:
+            try:
+                restored = self.project_manager.revert_to_version(version)
+
+                # Reload the ROM in the editor from the overwritten working file
+                document = self.get_current_document()
+                if document:
+                    document.rom_reader._load_rom()
+
+                # Clear pending changes (working ROM now matches the snapshot)
+                self.change_tracker.clear_pending_changes()
+                self._update_project_ui()
+
+                self.statusBar().showMessage(f"Reverted to {restored}")
+
+            except RomEditorError as e:
+                _handle_rom_operation_error(self, "revert version", e)
+            except Exception as e:
+                logger.exception(f"Unexpected error reverting: {type(e).__name__}: {e}")
+                QMessageBox.critical(
+                    self,
+                    "Error",
+                    f"Unexpected error reverting:\n{type(e).__name__}: {e}",
+                )
+
+    def _on_delete_version(self, version: int):
+        """Confirm and soft-delete a version"""
+        commit = self.project_manager.get_commit_by_version(version)
+        if not commit:
+            return
+
+        snapshot_name = commit.snapshot_filename or f"v{version}"
+        reply = QMessageBox.question(
+            self,
+            "Delete Version",
+            f"Delete v{version} ({snapshot_name})?\n\n"
+            f"The snapshot file will be moved to _trash/.",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+
+        if reply == QMessageBox.Yes:
+            try:
+                self.project_manager.soft_delete_version(version)
+                self.statusBar().showMessage(f"Deleted v{version}")
+
+            except RomEditorError as e:
+                _handle_rom_operation_error(self, "delete version", e)
+            except Exception as e:
+                logger.exception(
+                    f"Unexpected error deleting version: {type(e).__name__}: {e}"
+                )
+                QMessageBox.critical(
+                    self,
+                    "Error",
+                    f"Unexpected error deleting version:\n{type(e).__name__}: {e}",
+                )

--- a/src/ui/recent_files_mixin.py
+++ b/src/ui/recent_files_mixin.py
@@ -41,17 +41,12 @@ class RecentFilesMixin:
             # Add each recent file
             for i, entry in enumerate(recent_files, 1):
                 # Detect project entries (project:<path>) vs standalone ROM paths
-                if self.projects_enabled and entry.startswith("project:"):
+                if entry.startswith("project:"):
                     project_path = entry[len("project:") :]
                     folder_name = Path(project_path).name
                     action_text = f"{i}. [P] {folder_name}"
                     status_text = project_path
-                elif entry.startswith("project:"):
-                    # Projects disabled — skip project entries in menu
-                    continue
-                elif self.projects_enabled and ProjectManager.is_project_folder(
-                    str(Path(entry).parent)
-                ):
+                elif ProjectManager.is_project_folder(str(Path(entry).parent)):
                     # Legacy entry: ROM file inside a project folder
                     folder_name = Path(entry).parent.name
                     action_text = f"{i}. [P] {folder_name}"
@@ -86,7 +81,7 @@ class RecentFilesMixin:
         Args:
             entry: Full path to ROM file, or "project:<path>" for projects
         """
-        if self.projects_enabled and entry.startswith("project:"):
+        if entry.startswith("project:"):
             project_path = entry[len("project:") :]
             if not Path(project_path).exists():
                 QMessageBox.warning(
@@ -110,9 +105,7 @@ class RecentFilesMixin:
                 self._remove_recent_entry(entry)
                 return
             # Check if ROM lives inside a project folder (legacy entry)
-            if self.projects_enabled and ProjectManager.is_project_folder(
-                str(path.parent)
-            ):
+            if ProjectManager.is_project_folder(str(path.parent)):
                 self.open_project_path(str(path.parent))
             else:
                 self._open_rom_file(entry)

--- a/src/ui/session_mixin.py
+++ b/src/ui/session_mixin.py
@@ -41,7 +41,7 @@ class SessionMixin:
 
         for entry in session_files:
             try:
-                if self.projects_enabled and entry.startswith("project:"):
+                if entry.startswith("project:"):
                     # Explicit project tab
                     project_path = entry[len("project:") :]
                     if Path(project_path).exists():
@@ -50,11 +50,6 @@ class SessionMixin:
                         logger.warning(
                             f"Session project folder no longer exists: {project_path}"
                         )
-                elif entry.startswith("project:"):
-                    # Projects disabled — skip project entries
-                    logger.info(
-                        f"Skipping project session entry (projects disabled): {entry}"
-                    )
                 else:
                     path = Path(entry)
                     if not path.exists():
@@ -62,9 +57,7 @@ class SessionMixin:
                         continue
                     # Check if this ROM lives inside a project folder (legacy session data)
                     parent = path.parent
-                    if self.projects_enabled and ProjectManager.is_project_folder(
-                        str(parent)
-                    ):
+                    if ProjectManager.is_project_folder(str(parent)):
                         logger.info(
                             f"Session ROM is inside project folder, restoring as project: {parent}"
                         )
@@ -130,7 +123,7 @@ class SessionMixin:
 
     def show_settings(self):
         """Show settings dialog"""
-        dialog = SettingsDialog(self, projects_enabled=self.projects_enabled)
+        dialog = SettingsDialog(self)
         dialog.settings_changed.connect(self.on_settings_changed)
         dialog.exec()
 

--- a/src/ui/settings_dialog.py
+++ b/src/ui/settings_dialog.py
@@ -34,12 +34,11 @@ class SettingsDialog(QDialog):
     # Signal emitted when settings are applied
     settings_changed = Signal()
 
-    def __init__(self, parent=None, projects_enabled=False):
+    def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowTitle("Settings")
         self.setMinimumSize(600, 400)
         self.settings = get_settings()
-        self.projects_enabled = projects_enabled
         self.init_ui()
         self.load_settings()
 
@@ -78,23 +77,22 @@ class SettingsDialog(QDialog):
         paths_layout = QFormLayout()
         paths_group.setLayout(paths_layout)
 
-        # Projects directory setting (only when projects feature is enabled)
-        if self.projects_enabled:
-            projects_layout = QHBoxLayout()
-            self.projects_path_edit = QLineEdit()
-            self.projects_path_edit.setPlaceholderText("Path to store ROM projects")
-            projects_layout.addWidget(self.projects_path_edit)
+        # Projects directory setting
+        projects_layout = QHBoxLayout()
+        self.projects_path_edit = QLineEdit()
+        self.projects_path_edit.setPlaceholderText("Path to store ROM projects")
+        projects_layout.addWidget(self.projects_path_edit)
 
-            browse_projects_button = QPushButton("Browse...")
-            browse_projects_button.clicked.connect(self.browse_projects_directory)
-            projects_layout.addWidget(browse_projects_button)
+        browse_projects_button = QPushButton("Browse...")
+        browse_projects_button.clicked.connect(self.browse_projects_directory)
+        projects_layout.addWidget(browse_projects_button)
 
-            paths_layout.addRow("Projects Directory:", projects_layout)
+        paths_layout.addRow("Projects Directory:", projects_layout)
 
-            # Add help text for projects
-            projects_help = QLabel("Location where ROM tuning projects are stored")
-            projects_help.setStyleSheet("color: gray; font-size: 10px;")
-            paths_layout.addRow("", projects_help)
+        # Add help text for projects
+        projects_help = QLabel("Location where ROM tuning projects are stored")
+        projects_help.setStyleSheet("color: gray; font-size: 10px;")
+        paths_layout.addRow("", projects_help)
 
         # Metadata directory setting
         metadata_layout = QHBoxLayout()
@@ -277,10 +275,9 @@ class SettingsDialog(QDialog):
 
     def load_settings(self):
         """Load current settings into the UI"""
-        # Load projects directory (only when projects feature is enabled)
-        if self.projects_enabled:
-            projects_dir = self.settings.get_projects_directory()
-            self.projects_path_edit.setText(projects_dir)
+        # Load projects directory
+        projects_dir = self.settings.get_projects_directory()
+        self.projects_path_edit.setText(projects_dir)
 
         # Load metadata directory
         metadata_dir = self.settings.get_metadata_directory()
@@ -398,11 +395,10 @@ class SettingsDialog(QDialog):
 
     def apply_settings(self):
         """Apply settings without closing the dialog"""
-        # Save projects directory (only when projects feature is enabled)
-        if self.projects_enabled:
-            projects_dir = self.projects_path_edit.text().strip()
-            if projects_dir:
-                self.settings.set_projects_directory(projects_dir)
+        # Save projects directory
+        projects_dir = self.projects_path_edit.text().strip()
+        if projects_dir:
+            self.settings.set_projects_directory(projects_dir)
 
         # Save metadata directory
         metadata_dir = self.metadata_path_edit.text().strip()

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -1,0 +1,501 @@
+"""
+Tests for ProjectManager: tuning log, soft delete, revert, commit flow.
+"""
+
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from src.core.project_manager import ProjectManager
+from src.core.version_models import (
+    Project,
+    OriginalRomInfo,
+    Commit,
+    TableChanges,
+    CellChange,
+)
+from src.core.exceptions import ProjectError
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rom_definition():
+    """Mock ROM definition with romid attributes"""
+    defn = MagicMock()
+    defn.romid.internalidstring = "LF9VEB"
+    defn.romid.xmlid = "LF9VEB_XML"
+    defn.romid.make = "Subaru"
+    defn.romid.model = "WRX"
+    return defn
+
+
+@pytest.fixture
+def source_rom(tmp_path):
+    """Create a fake source ROM file"""
+    rom_file = tmp_path / "source" / "stock.bin"
+    rom_file.parent.mkdir()
+    rom_file.write_bytes(b"\x00" * 1024)
+    return rom_file
+
+
+@pytest.fixture
+def project_dir(tmp_path):
+    """Return a clean project directory path"""
+    return tmp_path / "my_tune"
+
+
+@pytest.fixture
+def pm(project_dir, source_rom, rom_definition):
+    """Create a ProjectManager with a fresh project"""
+    mgr = ProjectManager()
+    mgr.create_project(
+        project_path=str(project_dir),
+        project_name="Test Tune",
+        source_rom_path=str(source_rom),
+        rom_definition=rom_definition,
+    )
+    return mgr
+
+
+def _make_changes(table_name="Fuel Map", n_cells=3):
+    """Create a list of TableChanges for testing"""
+    cells = [
+        CellChange(
+            table_name=table_name,
+            table_address="0x1000",
+            row=i,
+            col=0,
+            old_value=10.0 + i,
+            new_value=12.0 + i,
+            old_raw=10.0 + i,
+            new_raw=12.0 + i,
+        )
+        for i in range(n_cells)
+    ]
+    return [
+        TableChanges(table_name=table_name, table_address="0x1000", cell_changes=cells)
+    ]
+
+
+# ===========================================================================
+# create_project
+# ===========================================================================
+
+
+class TestCreateProject:
+    def test_working_rom_naming(self, pm, project_dir):
+        """Working ROM should be {ROMID}.bin, not v1_*_working.bin"""
+        assert pm.current_project.working_rom == "LF9VEB.bin"
+        assert (project_dir / "LF9VEB.bin").exists()
+
+    def test_v0_original_created(self, pm, project_dir):
+        """v0 original ROM should exist"""
+        assert (project_dir / "v0_LF9VEB_original.bin").exists()
+
+    def test_tuning_log_created(self, pm, project_dir):
+        """TUNING_LOG.md should be created with header"""
+        log_path = project_dir / "TUNING_LOG.md"
+        assert log_path.exists()
+        content = log_path.read_text()
+        assert "# Tuning Log" in content
+        assert "LF9VEB" in content
+        assert "Subaru" in content
+        assert "WRX" in content
+
+    def test_project_json_no_last_suffix(self, pm, project_dir):
+        """project.json should not have last_suffix or settings fields"""
+        data = json.loads((project_dir / "project.json").read_text())
+        assert "last_suffix" not in data
+        assert "settings" not in data
+
+    def test_initial_commit_is_v0(self, pm):
+        """Initial commit should be version 0"""
+        assert len(pm.commits) == 1
+        assert pm.commits[0].version == 0
+        assert pm.commits[0].snapshot_filename == "v0_LF9VEB_original.bin"
+
+
+# ===========================================================================
+# commit_changes
+# ===========================================================================
+
+
+class TestCommitChanges:
+    def test_commit_creates_snapshot(self, pm, project_dir):
+        """Commit should always create a snapshot file"""
+        changes = _make_changes()
+        commit = pm.commit_changes(
+            message="Test commit",
+            changes=changes,
+            version_name="test_v1",
+        )
+        assert commit.version == 1
+        assert commit.snapshot_filename == "v1_LF9VEB_test_v1.bin"
+        assert (project_dir / "v1_LF9VEB_test_v1.bin").exists()
+
+    def test_commit_appends_tuning_log(self, pm, project_dir):
+        """Commit should append to TUNING_LOG.md"""
+        changes = _make_changes()
+        pm.commit_changes(
+            message="Added fuel enrichment",
+            changes=changes,
+            version_name="fuel_tune",
+        )
+        log = (project_dir / "TUNING_LOG.md").read_text(encoding="utf-8")
+        assert "## v1" in log
+        assert "fuel_tune" in log
+        assert "Added fuel enrichment" in log
+        assert "Fuel Map" in log
+
+    def test_tuning_log_direction_increase(self, pm, project_dir):
+        """Log should show increase direction for all-increasing changes"""
+        cells = [
+            CellChange(
+                table_name="Timing",
+                table_address="0x2000",
+                row=0,
+                col=0,
+                old_value=10.0,
+                new_value=15.0,
+                old_raw=10.0,
+                new_raw=15.0,
+            ),
+        ]
+        changes = [
+            TableChanges(
+                table_name="Timing", table_address="0x2000", cell_changes=cells
+            )
+        ]
+        pm.commit_changes(message="More timing", changes=changes, version_name="timing")
+        log = (project_dir / "TUNING_LOG.md").read_text(encoding="utf-8")
+        assert "\u2191" in log  # up arrow
+
+    def test_tuning_log_based_on_previous(self, pm, project_dir):
+        """Second commit's log should reference first commit's snapshot"""
+        pm.commit_changes(message="v1", changes=_make_changes(), version_name="first")
+        pm.commit_changes(message="v2", changes=_make_changes(), version_name="second")
+        log = (project_dir / "TUNING_LOG.md").read_text(encoding="utf-8")
+        assert "v1_LF9VEB_first.bin" in log
+
+    def test_sequential_versions(self, pm):
+        """Multiple commits should increment version numbers"""
+        pm.commit_changes(message="v1", changes=_make_changes(), version_name="a")
+        pm.commit_changes(message="v2", changes=_make_changes(), version_name="b")
+        pm.commit_changes(message="v3", changes=_make_changes(), version_name="c")
+
+        assert pm.commits[-1].version == 3
+        assert pm.commits[-2].version == 2
+        assert pm.commits[-3].version == 1
+
+    def test_commit_requires_project(self):
+        """Commit should fail if no project is open"""
+        mgr = ProjectManager()
+        with pytest.raises(ProjectError):
+            mgr.commit_changes(message="x", changes=[], version_name="y")
+
+    def test_has_snapshot_always_true(self, pm):
+        """Every commit should have has_snapshot=True"""
+        commit = pm.commit_changes(
+            message="test", changes=_make_changes(), version_name="snap"
+        )
+        assert commit.has_snapshot is True
+
+
+# ===========================================================================
+# soft_delete_version
+# ===========================================================================
+
+
+class TestSoftDelete:
+    def test_soft_delete_moves_to_trash(self, pm, project_dir):
+        """Soft delete should move snapshot to _trash/"""
+        pm.commit_changes(
+            message="v1", changes=_make_changes(), version_name="deleteme"
+        )
+        pm.soft_delete_version(1)
+
+        assert not (project_dir / "v1_LF9VEB_deleteme.bin").exists()
+        assert (project_dir / "_trash" / "v1_LF9VEB_deleteme.bin").exists()
+
+    def test_soft_delete_marks_commit(self, pm):
+        """Soft delete should set deleted=True on the commit"""
+        pm.commit_changes(message="v1", changes=_make_changes(), version_name="d")
+        pm.soft_delete_version(1)
+
+        commit = pm.get_commit_by_version(1)
+        assert commit.deleted is True
+
+    def test_soft_delete_persists_to_json(self, pm, project_dir):
+        """Deleted flag should be saved to commits.json"""
+        pm.commit_changes(message="v1", changes=_make_changes(), version_name="d")
+        pm.soft_delete_version(1)
+
+        data = json.loads((project_dir / "commits.json").read_text())
+        v1_commit = [c for c in data["commits"] if c.get("version") == 1][0]
+        assert v1_commit["deleted"] is True
+
+    def test_cannot_delete_v0(self, pm):
+        """Cannot delete the original ROM (v0)"""
+        with pytest.raises(ProjectError, match="Cannot delete"):
+            pm.soft_delete_version(0)
+
+    def test_cannot_double_delete(self, pm):
+        """Cannot delete an already-deleted version"""
+        pm.commit_changes(message="v1", changes=_make_changes(), version_name="d")
+        pm.soft_delete_version(1)
+        with pytest.raises(ProjectError, match="already deleted"):
+            pm.soft_delete_version(1)
+
+    def test_delete_nonexistent_version(self, pm):
+        """Deleting a nonexistent version should raise"""
+        with pytest.raises(ProjectError, match="not found"):
+            pm.soft_delete_version(99)
+
+
+# ===========================================================================
+# revert_to_version
+# ===========================================================================
+
+
+class TestRevert:
+    def test_revert_overwrites_working_rom(self, pm, project_dir):
+        """Revert should overwrite the working ROM with snapshot data"""
+        # Modify working ROM to make it different
+        working = project_dir / "LF9VEB.bin"
+        original_data = working.read_bytes()
+
+        pm.commit_changes(message="v1", changes=_make_changes(), version_name="base")
+
+        # Corrupt the working file to simulate edits
+        working.write_bytes(b"\xff" * len(original_data))
+
+        pm.revert_to_version(1)
+
+        # Working ROM should now match the v1 snapshot
+        assert working.read_bytes() == original_data
+
+    def test_revert_deletes_newer_versions(self, pm, project_dir):
+        """Revert should soft-delete versions newer than target"""
+        pm.commit_changes(message="v1", changes=_make_changes(), version_name="a")
+        pm.commit_changes(message="v2", changes=_make_changes(), version_name="b")
+        pm.commit_changes(message="v3", changes=_make_changes(), version_name="c")
+
+        pm.revert_to_version(1)
+
+        assert pm.get_commit_by_version(1).deleted is False
+        assert pm.get_commit_by_version(2).deleted is True
+        assert pm.get_commit_by_version(3).deleted is True
+
+    def test_revert_appends_to_log(self, pm, project_dir):
+        """Revert should append an entry to TUNING_LOG.md"""
+        pm.commit_changes(message="v1", changes=_make_changes(), version_name="base")
+        pm.revert_to_version(1)
+
+        log = (project_dir / "TUNING_LOG.md").read_text(encoding="utf-8")
+        assert "Reverted to v1" in log
+
+    def test_revert_to_v0(self, pm, project_dir, source_rom):
+        """Revert to v0 should restore original ROM"""
+        pm.commit_changes(message="v1", changes=_make_changes(), version_name="a")
+
+        # Modify working file
+        working = project_dir / "LF9VEB.bin"
+        working.write_bytes(b"\xff" * 1024)
+
+        pm.revert_to_version(0)
+
+        assert working.read_bytes() == source_rom.read_bytes()
+
+    def test_version_numbers_stay_monotonic(self, pm):
+        """After revert, next commit version should be max+1"""
+        pm.commit_changes(message="v1", changes=_make_changes(), version_name="a")
+        pm.commit_changes(message="v2", changes=_make_changes(), version_name="b")
+        pm.commit_changes(message="v3", changes=_make_changes(), version_name="c")
+
+        pm.revert_to_version(1)
+
+        # Next version should be 4 (max=3, +1)
+        assert pm.get_next_version() == 4
+
+    def test_revert_nonexistent_version(self, pm):
+        """Revert to nonexistent version should raise"""
+        with pytest.raises(ProjectError, match="not found"):
+            pm.revert_to_version(99)
+
+    def test_revert_deleted_version(self, pm):
+        """Revert to deleted version should raise"""
+        pm.commit_changes(message="v1", changes=_make_changes(), version_name="d")
+        pm.soft_delete_version(1)
+        with pytest.raises(ProjectError, match="deleted"):
+            pm.revert_to_version(1)
+
+
+# ===========================================================================
+# Commit model — deleted field
+# ===========================================================================
+
+
+class TestCommitDeletedField:
+    def test_deleted_default_false(self):
+        """Commit.deleted should default to False"""
+        commit = Commit.create(message="test", changes=[], version=1)
+        assert commit.deleted is False
+
+    def test_deleted_serialization(self):
+        """deleted field should serialize/deserialize"""
+        commit = Commit.create(message="test", changes=[], version=1)
+        commit.deleted = True
+        data = commit.to_dict()
+        assert data["deleted"] is True
+
+        restored = Commit.from_dict(data)
+        assert restored.deleted is True
+
+    def test_backward_compat_missing_deleted(self):
+        """Old commits without deleted field should default to False"""
+        data = {
+            "id": "abc",
+            "version": 1,
+            "parent_id": None,
+            "message": "test",
+            "timestamp": "2026-01-01T00:00:00",
+            "author": "User",
+            "tables_modified": [],
+            "changes": [],
+        }
+        commit = Commit.from_dict(data)
+        assert commit.deleted is False
+
+
+# ===========================================================================
+# Project model — removed fields
+# ===========================================================================
+
+
+class TestProjectModelCleanup:
+    def test_project_no_last_suffix(self):
+        """Project should not have last_suffix attribute"""
+        assert (
+            not hasattr(Project, "last_suffix")
+            or "last_suffix" not in Project.__dataclass_fields__
+        )
+
+    def test_project_no_settings(self):
+        """Project should not have settings attribute"""
+        assert (
+            not hasattr(Project, "settings")
+            or "settings" not in Project.__dataclass_fields__
+        )
+
+    def test_backward_compat_old_project_json(self, tmp_path):
+        """Opening an old project.json with last_suffix/settings should still work"""
+        data = {
+            "version": "1.0",
+            "name": "Old Project",
+            "description": "",
+            "created_at": "2026-01-01T00:00:00",
+            "updated_at": "2026-01-01T00:00:00",
+            "original_rom": {
+                "filename": "v0_LF9VEB_original.bin",
+                "size": 1024,
+                "checksum_sha256": "abc123",
+                "rom_id": "LF9VEB",
+                "definition_xmlid": "LF9VEB_XML",
+                "make": "Subaru",
+                "model": "WRX",
+            },
+            "working_rom": "v1_LF9VEB_working.bin",
+            "head_commit_id": None,
+            "head_version": 0,
+            "last_suffix": "original",
+            "settings": {"auto_snapshot_interval": 10},
+        }
+        # from_dict should just ignore unknown fields (via .get() defaults)
+        project = Project.from_dict(data, str(tmp_path))
+        assert project.name == "Old Project"
+        assert project.working_rom == "v1_LF9VEB_working.bin"
+
+
+# ===========================================================================
+# Backward compatibility — old project open
+# ===========================================================================
+
+
+class TestBackwardCompat:
+    def test_old_working_rom_pattern(self, tmp_path, rom_definition):
+        """Old projects with v1_*_working.bin should still open"""
+        proj_dir = tmp_path / "old_project"
+        proj_dir.mkdir()
+
+        # Create old-style project files
+        rom_data = b"\x00" * 1024
+
+        (proj_dir / "v0_LF9VEB_original.bin").write_bytes(rom_data)
+        (proj_dir / "v1_LF9VEB_working.bin").write_bytes(rom_data)
+
+        project_data = {
+            "version": "1.0",
+            "name": "Old Project",
+            "description": "",
+            "created_at": "2026-01-01T00:00:00",
+            "updated_at": "2026-01-01T00:00:00",
+            "original_rom": {
+                "filename": "v0_LF9VEB_original.bin",
+                "size": 1024,
+                "checksum_sha256": "abc",
+                "rom_id": "LF9VEB",
+                "definition_xmlid": "LF9VEB_XML",
+                "make": "Subaru",
+                "model": "WRX",
+            },
+            "working_rom": "v1_LF9VEB_working.bin",
+            "head_commit_id": None,
+            "head_version": 0,
+            "last_suffix": "original",
+            "settings": {},
+        }
+        (proj_dir / "project.json").write_text(json.dumps(project_data))
+
+        commits_data = {"version": "1.0", "commits": []}
+        (proj_dir / "commits.json").write_text(json.dumps(commits_data))
+
+        mgr = ProjectManager()
+        project = mgr.open_project(str(proj_dir))
+        assert project.working_rom == "v1_LF9VEB_working.bin"
+        assert Path(project.working_rom_path).exists()
+
+
+# ===========================================================================
+# CommitDialog sanitization
+# ===========================================================================
+
+
+class TestCommitDialogSanitization:
+    def test_sanitize_basic(self):
+        from src.ui.commit_dialog import CommitDialog
+
+        assert CommitDialog._sanitize_name("EGR Delete") == "egr_delete"
+
+    def test_sanitize_special_chars(self):
+        from src.ui.commit_dialog import CommitDialog
+
+        assert CommitDialog._sanitize_name("stage-1 (WOT)") == "stage1_wot"
+
+    def test_sanitize_already_clean(self):
+        from src.ui.commit_dialog import CommitDialog
+
+        assert CommitDialog._sanitize_name("fuel_tune") == "fuel_tune"
+
+    def test_sanitize_empty(self):
+        from src.ui.commit_dialog import CommitDialog
+
+        assert CommitDialog._sanitize_name("   ") == ""
+
+    def test_sanitize_numbers(self):
+        from src.ui.commit_dialog import CommitDialog
+
+        assert CommitDialog._sanitize_name("v2 timing") == "v2_timing"

--- a/tests/test_project_session.py
+++ b/tests/test_project_session.py
@@ -35,8 +35,7 @@ def _make_document(rom_path, project_path=None, modified=False):
 class _SessionHost(SessionMixin):
     """Minimal host satisfying SessionMixin dependencies for unit tests."""
 
-    def __init__(self, documents=None, session_files=None, projects_enabled=True):
-        self.projects_enabled = projects_enabled
+    def __init__(self, documents=None, session_files=None):
         self.settings = MagicMock()
         self.settings.get_session_files.return_value = session_files or []
         self.tab_widget = MagicMock()
@@ -53,8 +52,7 @@ class _SessionHost(SessionMixin):
 class _RecentHost(RecentFilesMixin):
     """Minimal host satisfying RecentFilesMixin dependencies for unit tests."""
 
-    def __init__(self, projects_enabled=True):
-        self.projects_enabled = projects_enabled
+    def __init__(self):
         self.settings = MagicMock()
         self.file_menu = MagicMock()
         self.recent_files_actions = []


### PR DESCRIPTION
## Summary

- **Mandatory version snapshots** — Every commit creates a named ROM snapshot (`v{N}_{ROMID}_{name}.bin`) with an auto-generated `TUNING_LOG.md` entry containing table change summaries and direction indicators
- **Revert & soft delete** — Restore any previous version as the working ROM, or soft-delete bad versions to `_trash/`
- **Projects always enabled** — Removed `--enable-projects` feature flag; project menu items always visible
- **Redesigned commit dialog** — Required version name with auto-sanitization and filename preview, optional description
- **Read-only version comparison** — History viewer opens a CompareWindow (copy buttons hidden) to visualize changes between versions
- **UI polish** — Version History toolbar button, window geometry persistence, commit clears modified flag, message line breaks preserved

## Test plan

- [x] 355 tests pass (37 new for project management)
- [x] `black --check src/ tests/ main.py` — all clean
- [x] `flake8` syntax check — 0 errors
- [x] Create new project → verify `v0_*_original.bin` + `{ROMID}.bin` + `TUNING_LOG.md`
- [x] Commit with version name → snapshot created, log entry appended
- [x] Soft delete → file moved to `_trash/`, hidden in history
- [x] Revert → working ROM overwritten, newer versions cascade-deleted
- [x] Old projects with `v1_*_working.bin` naming still open correctly
- [x] Commit clears modified flag (no spurious unsaved-changes prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)