### PR TITLE
fix: settings dialog crash on fresh install + version stamping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,12 @@ jobs:
         pip install -r requirements-dev.txt
         pip install -r packaging/requirements-build.txt
 
+    - name: Stamp version from tag
+      run: |
+        $version = "${{ github.ref_name }}".TrimStart("v")
+        (Get-Content src/utils/constants.py) -replace 'APP_VERSION = ".*"', "APP_VERSION = `"$version`"" | Set-Content src/utils/constants.py
+      shell: pwsh
+
     - name: Run tests
       run: pytest
 
@@ -98,6 +104,11 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
         pip install -r packaging/requirements-build.txt
+
+    - name: Stamp version from tag
+      run: |
+        VERSION="${GITHUB_REF_NAME#v}"
+        sed -i "s/APP_VERSION = \".*\"/APP_VERSION = \"$VERSION\"/" src/utils/constants.py
 
     - name: Run tests
       run: pytest

--- a/src/ui/settings_dialog.py
+++ b/src/ui/settings_dialog.py
@@ -56,7 +56,10 @@ class SettingsDialog(QDialog):
         self.create_appearance_tab()
         self.create_editor_tab()
         self.create_tools_tab()
-        self.create_ecu_tab()
+        try:
+            self.create_ecu_tab()
+        except ImportError:
+            pass
 
         # Dialog buttons (OK, Cancel, Apply)
         button_box = QDialogButtonBox(
@@ -275,6 +278,9 @@ class SettingsDialog(QDialog):
 
     def create_ecu_tab(self):
         """Create the ECU settings tab"""
+        # Import early so the tab is skipped entirely if the module is missing
+        from src.ecu.flash_manager import SECURE_MODULE_AVAILABLE
+
         tab = QWidget()
         layout = QVBoxLayout()
         tab.setLayout(layout)
@@ -315,8 +321,6 @@ class SettingsDialog(QDialog):
         status_group = QGroupBox("Flash Security Module")
         status_layout = QVBoxLayout()
         status_group.setLayout(status_layout)
-
-        from src.ecu.flash_manager import SECURE_MODULE_AVAILABLE
 
         if SECURE_MODULE_AVAILABLE:
             status_label = QLabel("Installed — flash operations are available")
@@ -411,9 +415,10 @@ class SettingsDialog(QDialog):
         # Load MCP auto-start setting
         self.mcp_auto_start_checkbox.setChecked(self.settings.get_mcp_auto_start())
 
-        # Load J2534 DLL path
-        j2534_path = self.settings.get_j2534_dll_path()
-        self.j2534_dll_edit.setText(j2534_path)
+        # Load J2534 DLL path (only if ECU tab was created)
+        if hasattr(self, "j2534_dll_edit"):
+            j2534_path = self.settings.get_j2534_dll_path()
+            self.j2534_dll_edit.setText(j2534_path)
 
     def browse_projects_directory(self):
         """Open directory browser for projects directory"""
@@ -538,9 +543,10 @@ class SettingsDialog(QDialog):
         # Save MCP auto-start setting
         self.settings.set_mcp_auto_start(self.mcp_auto_start_checkbox.isChecked())
 
-        # Save J2534 DLL path
-        j2534_path = self.j2534_dll_edit.text().strip()
-        self.settings.set_j2534_dll_path(j2534_path)
+        # Save J2534 DLL path (only if ECU tab was created)
+        if hasattr(self, "j2534_dll_edit"):
+            j2534_path = self.j2534_dll_edit.text().strip()
+            self.settings.set_j2534_dll_path(j2534_path)
 
         # Emit signal that settings changed
         self.settings_changed.emit()

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -6,7 +6,7 @@ Centralized location for all magic numbers and configuration constants.
 
 # Application metadata
 APP_NAME = "NC Flash"
-APP_VERSION = "2.0.0"
+APP_VERSION = "dev"
 APP_VERSION_STRING = f"v{APP_VERSION}"
 APP_DESCRIPTION = "An open-source ROM editor for NC Miata ECUs"
 


### PR DESCRIPTION
## Summary
- **Settings dialog crash**: The ECU tab imported `src.ecu.flash_manager` at a point where widgets were already created. On fresh installs (where `src.ecu` doesn't exist), this crashed silently and the dialog never opened. Moved the import to the top of the method so the entire tab is skipped gracefully via `try/except ImportError`.
- **Version mismatch**: `APP_VERSION` was hardcoded to `2.0.0` and never updated by the release pipeline. Added a "Stamp version from tag" step to both Windows and Linux build jobs so the git tag version is written into `constants.py` before building. Local dev now shows `vdev`.

Closes #16

## Test plan
- [x] Verified `SettingsDialog` opens with 4 tabs (no ECU) when `src.ecu` is missing
- [x] 355 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)