### PR TITLE
feat: interleaved 3D table support for TCM ROMs

### DIFF
--- a/.claude/notes.md
+++ b/.claude/notes.md
@@ -10,6 +10,9 @@
 - CI/release secure module checkout steps — needs `SECURE_MODULE_PAT` secret
 - Will merge to master after user testing
 
+## Recent Completed Work (Mar 23, 2026) - Interleaved 3D Tables
+- **Interleaved 3D table support** — Added `TableLayout` enum (`CONTIGUOUS`/`INTERLEAVED`), `layout` attribute parsing in definition parser, and interleaved read/write/cell-edit/axis-edit in `RomReader`. 256 lines of tests in `test_interleaved_tables.py`. Enables TCM ROM support where Y-axis values are interleaved with data rows.
+
 ## Recent Completed Work (Mar 5, 2026) - Pipeline Fixes
 - **Black formatting** — Ran black on 21 unformatted files (was failing CI lint)
 - **Release pytest fix** — Changed `requirements.txt` to `requirements-dev.txt` in release.yml (pytest was missing)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to NC Flash are documented here.
 
 ## [Unreleased]
 
+### Added
+- **Interleaved 3D table support** — TCM-style ROMs that store Y-axis values interleaved with data rows (`[M][N][X_axis][Y0 D0..DM-1][Y1 D1..DM-1]...`) are now fully supported. Read, bulk write, single-cell edit, and Y-axis edit all handle the interleaved layout. Enabled via `layout="interleaved"` attribute in XML definitions
+
 ### Fixed
 - **Settings dialog crash on fresh install** — Clicking Settings did nothing on release builds because the ECU tab imported `src.ecu.flash_manager` which doesn't exist without the ECU module. The import now fails early and the ECU tab is gracefully skipped (#16)
 - **Version mismatch in About dialog** — Release builds showed `v2.0.0` regardless of the git tag. The release pipeline now stamps `APP_VERSION` from the tag before building (#16)

--- a/src/core/definition_parser.py
+++ b/src/core/definition_parser.py
@@ -9,7 +9,15 @@ from typing import Optional
 from pathlib import Path
 import logging
 
-from .rom_definition import RomDefinition, RomID, Scaling, Table, TableType, AxisType, TableLayout
+from .rom_definition import (
+    RomDefinition,
+    RomID,
+    Scaling,
+    Table,
+    TableType,
+    AxisType,
+    TableLayout,
+)
 from .exceptions import (
     DefinitionNotFoundError,
     DefinitionParseError,

--- a/src/core/rom_definition.py
+++ b/src/core/rom_definition.py
@@ -30,8 +30,10 @@ class AxisType(Enum):
 class TableLayout(Enum):
     """Memory layout for table data"""
 
-    CONTIGUOUS = "contiguous"      # Standard: axes and data at separate contiguous addresses
-    INTERLEAVED = "interleaved"    # TCM-style: [M][N][X_axis][Y0 D0..DM][Y1 D1..DM]...
+    CONTIGUOUS = (
+        "contiguous"  # Standard: axes and data at separate contiguous addresses
+    )
+    INTERLEAVED = "interleaved"  # TCM-style: [M][N][X_axis][Y0 D0..DM][Y1 D1..DM]...
 
 
 @dataclass

--- a/src/core/rom_reader.py
+++ b/src/core/rom_reader.py
@@ -15,7 +15,14 @@ from typing import Optional, Union
 import logging
 from simpleeval import simple_eval
 
-from .rom_definition import RomDefinition, Table, Scaling, TableType, TableLayout, AxisType
+from .rom_definition import (
+    RomDefinition,
+    Table,
+    Scaling,
+    TableType,
+    TableLayout,
+    AxisType,
+)
 from .storage_types import STORAGE_TYPE_FORMAT, DEFAULT_FORMAT_CHAR
 from .exceptions import (
     RomFileNotFoundError,
@@ -482,15 +489,17 @@ class RomReader:
         Each row is (M+1) bytes: 1 Y-axis byte followed by M data bytes.
         """
         base = table.address_int
-        m = self.rom_data[base]       # X axis count
-        n = self.rom_data[base + 1]   # Y axis count (row count)
+        m = self.rom_data[base]  # X axis count
+        n = self.rom_data[base + 1]  # Y axis count (row count)
         x_start = base + 2
         row_start = x_start + m
         stride = m + 1
 
         # Read X axis (contiguous)
         x_axis = table.x_axis
-        x_raw = np.array([self.rom_data[x_start + i] for i in range(m)], dtype=np.float64)
+        x_raw = np.array(
+            [self.rom_data[x_start + i] for i in range(m)], dtype=np.float64
+        )
         if x_axis:
             x_scaling = self.definition.get_scaling(x_axis.scaling)
             if x_scaling:
@@ -763,8 +772,7 @@ class RomReader:
 
         # Calculate the byte offset
         bytes_per_elem = scaling.bytes_per_element
-        if (table.layout == TableLayout.INTERLEAVED
-                and axis_type == "y_axis"):
+        if table.layout == TableLayout.INTERLEAVED and axis_type == "y_axis":
             # Y axis values are interleaved: first byte of each row
             base = table.address_int
             m = self.rom_data[base]

--- a/tests/test_interleaved_tables.py
+++ b/tests/test_interleaved_tables.py
@@ -10,23 +10,43 @@ import pytest
 import struct
 
 from src.core.rom_definition import (
-    RomDefinition, RomID, Scaling, Table, TableType, AxisType, TableLayout,
+    RomDefinition,
+    RomID,
+    Scaling,
+    Table,
+    TableType,
+    AxisType,
+    TableLayout,
 )
 from src.core.rom_reader import RomReader, ScalingConverter
 
 
 def make_romid():
     return RomID(
-        xmlid="TEST", internalidaddress="0", internalidstring="TEST",
-        ecuid="TEST", make="Test", model="Test", flashmethod="",
-        memmodel="SH7055", checksummodule="",
+        xmlid="TEST",
+        internalidaddress="0",
+        internalidstring="TEST",
+        ecuid="TEST",
+        make="Test",
+        model="Test",
+        flashmethod="",
+        memmodel="SH7055",
+        checksummodule="",
     )
 
 
 def make_scaling(name="u8", storagetype="uint8"):
     return Scaling(
-        name=name, units="", toexpr="x", frexpr="x", format="%d",
-        min=0, max=255, inc=1, storagetype=storagetype, endian="big",
+        name=name,
+        units="",
+        toexpr="x",
+        frexpr="x",
+        format="%d",
+        min=0,
+        max=255,
+        inc=1,
+        storagetype=storagetype,
+        endian="big",
     )
 
 
@@ -50,17 +70,29 @@ def make_interleaved_table(name, base_hex, m, n, scaling_name="u8"):
     """Create a Table definition for an interleaved 3D table."""
     base = int(base_hex, 16)
     x_axis_child = Table(
-        name="X Axis", address=hex(base + 2)[2:], elements=m,
-        scaling=scaling_name, type=TableType.ONE_D, axis_type=AxisType.X_AXIS,
+        name="X Axis",
+        address=hex(base + 2)[2:],
+        elements=m,
+        scaling=scaling_name,
+        type=TableType.ONE_D,
+        axis_type=AxisType.X_AXIS,
     )
     y_axis_child = Table(
-        name="Y Axis", address=hex(base + 2 + m)[2:], elements=n,
-        scaling=scaling_name, type=TableType.ONE_D, axis_type=AxisType.Y_AXIS,
+        name="Y Axis",
+        address=hex(base + 2 + m)[2:],
+        elements=n,
+        scaling=scaling_name,
+        type=TableType.ONE_D,
+        axis_type=AxisType.Y_AXIS,
     )
     table = Table(
-        name=name, address=base_hex, elements=m * n,
-        scaling=scaling_name, type=TableType.THREE_D,
-        layout=TableLayout.INTERLEAVED, children=[x_axis_child, y_axis_child],
+        name=name,
+        address=base_hex,
+        elements=m * n,
+        scaling=scaling_name,
+        type=TableType.THREE_D,
+        layout=TableLayout.INTERLEAVED,
+        children=[x_axis_child, y_axis_child],
     )
     return table
 
@@ -134,8 +166,8 @@ class TestInterleavedRead:
         np.testing.assert_array_equal(result["y_axis"], y_vals)
         assert result["values"].shape == (8, 8)
         # Check specific cells
-        assert result["values"][0, 0] == 0   # row 0, col 0
-        assert result["values"][0, 7] == 7   # row 0, col 7
+        assert result["values"][0, 0] == 0  # row 0, col 0
+        assert result["values"][0, 7] == 7  # row 0, col 7
         assert result["values"][7, 0] == 70  # row 7, col 0
         assert result["values"][7, 7] == 77  # row 7, col 7
 
@@ -245,8 +277,11 @@ class TestContiguousUnchanged:
     def test_contiguous_table_has_default_layout(self):
         """Tables without layout attribute should default to contiguous."""
         table = Table(
-            name="test", address="1000", elements=10,
-            scaling="u8", type=TableType.TWO_D,
+            name="test",
+            address="1000",
+            elements=10,
+            scaling="u8",
+            type=TableType.TWO_D,
         )
         assert table.layout == TableLayout.CONTIGUOUS
 


### PR DESCRIPTION
## Summary
- Add `TableLayout` enum (`CONTIGUOUS` / `INTERLEAVED`) and `layout` XML attribute parsing
- Implement interleaved 3D table read/write/cell-edit/axis-edit in `RomReader` for TCM-style ROMs where Y-axis values are interleaved with data rows (`[M][N][X_axis][Y0 D0..DM-1][Y1 D1..DM-1]...`)
- 256 lines of tests covering 3x3, 8x8 reads, cell/bulk/axis write roundtrips, and contiguous backward compatibility

## Test plan
- [x] `black` formatting passes (4 files reformatted)
- [x] `pytest` — 362 tests pass (including 7 new interleaved tests)
- [x] Changelog updated under `[Unreleased]`

## Release
Tag as **v2.2.0** after merge (new feature = minor bump from v2.1.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)