### PR TITLE
feat: add drag-and-drop support for ROM files

### DIFF
--- a/.claude/notes.md
+++ b/.claude/notes.md
@@ -15,6 +15,9 @@
 - **Removed `Thinking-pad.md` from git** — Added to `.gitignore`, kept local file
 - **Branch `fix/house-cleaning`** created from `origin/master` with all changes staged
 
+## Recent Completed Work (Mar 27, 2026) - Drag-and-Drop
+- **Drag-and-drop ROM files** — Users can drag `.bin`/`.rom` files onto the main window to open them. Translucent blue overlay with dashed border shows during drag-over. Invalid file types show a descriptive error. Multiple files supported. Reuses existing open-file flow. 11 tests in `test_drag_drop.py`. (#20)
+
 ## Recent Completed Work (Mar 26, 2026) - Build Fix
 - **J2534 bridge frozen-app fix** — PyInstaller builds failed to load 32-bit DLL because frozen ctypes raises a different OSError than native bitness mismatch. Bridge fallback now detects both.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to NC Flash are documented here.
 
 ### Added
 - **Native ECU flashing** — Full J2534/UDS flash module replacing RomDrop integration. Read and write ECU ROMs directly via Tactrix OpenPort 2.0
+- **Drag-and-drop ROM files** — Drag `.bin` or `.rom` files onto the main window to open them. Visual overlay indicates the drop zone during drag-over. Invalid file types are rejected with a descriptive error message (#20)
 - **ECU Programming window** — Dedicated window (Tools > ECU Programming) replacing scattered ECU menu items. Auto-connects, shows battery voltage/engine RPM/ECU info in status cards, one-click flash with dynamic/full auto-detection, inline progress, auto-save ROM reads
 - **ECU Connect/Disconnect** — New menu actions in ECU menu to establish and hold a persistent J2534 connection. Operations reuse the open device instead of reconnecting each time. Status bar shows real connection state
 - **OBD-II PID reading** — Battery voltage (PID 0x42) and engine RPM (PID 0x0C) via standard OBD-II Service 0x01

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ from PySide6.QtWidgets import (
     QColorDialog,
 )
 from PySide6.QtCore import Qt, QTimer, QSize
-from PySide6.QtGui import QColor, QIcon, QPainter, QPen, QPixmap
+from PySide6.QtGui import QBrush, QColor, QFont, QIcon, QPainter, QPen, QPixmap
 from src.ui.icons import make_icon
 
 from src.utils.logging_config import setup_logging, get_logger
@@ -91,6 +91,45 @@ def handle_rom_operation_error(parent, operation: str, exception: Exception):
     error_msg = f"Failed to {operation}:\n{str(exception)}"
     logger.error(error_msg.replace("\n", " "))
     QMessageBox.critical(parent, "Error", error_msg)
+
+
+class _DropOverlayWidget(QWidget):
+    """Translucent overlay shown while dragging files over the main window."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAttribute(Qt.WA_TransparentForMouseEvents)
+        self.setAutoFillBackground(False)
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing)
+
+        # Semi-transparent background
+        painter.fillRect(self.rect(), QBrush(QColor(40, 120, 200, 60)))
+
+        # Dashed border
+        pen = QPen(QColor(40, 120, 200, 180), 3, Qt.DashLine)
+        painter.setPen(pen)
+        margin = 12
+        painter.drawRoundedRect(
+            margin,
+            margin,
+            self.width() - 2 * margin,
+            self.height() - 2 * margin,
+            12,
+            12,
+        )
+
+        # Centered text
+        painter.setPen(QColor(40, 120, 200, 220))
+        font = QFont()
+        font.setPointSize(18)
+        font.setBold(True)
+        painter.setFont(font)
+        painter.drawText(self.rect(), Qt.AlignCenter, "Drop ROM file here")
+
+        painter.end()
 
 
 class MainWindow(
@@ -175,6 +214,10 @@ class MainWindow(
         self.init_ui()
         self.init_menu()
         self._create_toolbar()
+
+        # Enable drag-and-drop for ROM files
+        self.setAcceptDrops(True)
+        self._drop_overlay = None  # lazily created in dragEnterEvent
 
         # Defer heavy work to after the window is shown:
         # - metadata directory check + setup wizard (modal dialog)
@@ -726,6 +769,103 @@ class MainWindow(
             self.open_project_path(str(parent))
         else:
             self._open_rom_file(file_path)
+
+    # ------------------------------------------------------------------
+    # Drag-and-drop support
+    # ------------------------------------------------------------------
+
+    #: File extensions accepted via drag-and-drop (matches File > Open dialog)
+    _DROP_EXTENSIONS = {".bin", ".rom"}
+
+    def _get_drop_file_paths(self, mime_data):
+        """Extract file paths from drop MIME data, returning only valid ROM files.
+
+        Returns:
+            list[str]: Paths with valid ROM extensions, or empty list.
+        """
+        if not mime_data.hasUrls():
+            return []
+        paths = []
+        for url in mime_data.urls():
+            if url.isLocalFile():
+                path = url.toLocalFile()
+                if Path(path).suffix.lower() in self._DROP_EXTENSIONS:
+                    paths.append(path)
+        return paths
+
+    def dragEnterEvent(self, event):
+        """Accept the drag if it contains at least one valid ROM file."""
+        paths = self._get_drop_file_paths(event.mimeData())
+        if paths:
+            event.acceptProposedAction()
+            self._show_drop_overlay()
+        else:
+            # Check if the user is dragging files with invalid extensions
+            if event.mimeData().hasUrls():
+                event.ignore()
+            else:
+                event.ignore()
+
+    def dragMoveEvent(self, event):
+        """Continue accepting the drag while over the window."""
+        if self._get_drop_file_paths(event.mimeData()):
+            event.acceptProposedAction()
+        else:
+            event.ignore()
+
+    def dragLeaveEvent(self, event):
+        """Remove visual feedback when drag leaves the window."""
+        self._hide_drop_overlay()
+        event.accept()
+
+    def dropEvent(self, event):
+        """Open dropped ROM files."""
+        self._hide_drop_overlay()
+
+        paths = self._get_drop_file_paths(event.mimeData())
+        if not paths:
+            # Files were dropped but none had valid extensions
+            if event.mimeData().hasUrls():
+                rejected = [
+                    url.toLocalFile()
+                    for url in event.mimeData().urls()
+                    if url.isLocalFile()
+                ]
+                ext_list = ", ".join(sorted(self._DROP_EXTENSIONS))
+                names = "\n".join(Path(p).name for p in rejected[:5])
+                if len(rejected) > 5:
+                    names += f"\n... and {len(rejected) - 5} more"
+                QMessageBox.warning(
+                    self,
+                    "Unsupported File Type",
+                    f"Cannot open the dropped file(s):\n\n{names}\n\n"
+                    f"Supported extensions: {ext_list}",
+                )
+            event.ignore()
+            return
+
+        event.acceptProposedAction()
+        logger.info(f"Drag-and-drop: opening {len(paths)} file(s)")
+
+        for file_path in paths:
+            parent = Path(file_path).parent
+            if ProjectManager.is_project_folder(str(parent)):
+                self.open_project_path(str(parent))
+            else:
+                self._open_rom_file(file_path)
+
+    def _show_drop_overlay(self):
+        """Show a translucent overlay indicating the drop zone is active."""
+        if self._drop_overlay is None:
+            self._drop_overlay = _DropOverlayWidget(self)
+        self._drop_overlay.setGeometry(self.centralWidget().geometry())
+        self._drop_overlay.show()
+        self._drop_overlay.raise_()
+
+    def _hide_drop_overlay(self):
+        """Hide the drop-zone overlay."""
+        if self._drop_overlay is not None:
+            self._drop_overlay.hide()
 
     def _write_workspace_state(self):
         """Write workspace.json listing all open ROMs for MCP server discovery.

--- a/tests/test_drag_drop.py
+++ b/tests/test_drag_drop.py
@@ -1,0 +1,107 @@
+"""
+Tests for drag-and-drop ROM file support on the main window.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+
+from PySide6.QtCore import QUrl, QMimeData, Qt
+from PySide6.QtWidgets import QApplication
+
+from main import MainWindow, _DropOverlayWidget
+
+# Ensure a QApplication exists (required for any Qt widget tests)
+_app = QApplication.instance() or QApplication([])
+
+
+# ---------------------------------------------------------------------------
+# _DropOverlayWidget
+# ---------------------------------------------------------------------------
+
+
+class TestDropOverlayWidget:
+    """Test the translucent overlay widget used during drag-over."""
+
+    def test_overlay_creates_and_paints(self):
+        """Overlay can be created and paints without error."""
+        overlay = _DropOverlayWidget()
+        overlay.resize(400, 300)
+        overlay.show()
+        overlay.repaint()  # force paintEvent
+        overlay.hide()
+        overlay.deleteLater()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mime_data(file_paths):
+    """Create a QMimeData with file URLs."""
+    mime = QMimeData()
+    urls = [QUrl.fromLocalFile(str(p)) for p in file_paths]
+    mime.setUrls(urls)
+    return mime
+
+
+class _FakeSelf:
+    """Minimal stand-in for MainWindow so we can test _get_drop_file_paths."""
+
+    _DROP_EXTENSIONS = MainWindow._DROP_EXTENSIONS
+
+
+class TestGetDropFilePaths:
+    """Test the helper that filters drop MIME data for valid ROM files."""
+
+    def test_accepts_bin_files(self):
+        mime = _make_mime_data(["/tmp/test.bin"])
+        paths = MainWindow._get_drop_file_paths(_FakeSelf(), mime)
+        assert paths == ["/tmp/test.bin"]
+
+    def test_accepts_rom_files(self):
+        mime = _make_mime_data(["/tmp/test.rom"])
+        paths = MainWindow._get_drop_file_paths(_FakeSelf(), mime)
+        assert paths == ["/tmp/test.rom"]
+
+    def test_case_insensitive_extension(self):
+        mime = _make_mime_data(["/tmp/test.BIN", "/tmp/test.Rom"])
+        paths = MainWindow._get_drop_file_paths(_FakeSelf(), mime)
+        assert len(paths) == 2
+
+    def test_rejects_invalid_extensions(self):
+        mime = _make_mime_data(["/tmp/test.txt", "/tmp/test.exe", "/tmp/readme.md"])
+        paths = MainWindow._get_drop_file_paths(_FakeSelf(), mime)
+        assert paths == []
+
+    def test_mixed_valid_and_invalid(self):
+        mime = _make_mime_data(["/tmp/a.bin", "/tmp/b.txt", "/tmp/c.rom"])
+        paths = MainWindow._get_drop_file_paths(_FakeSelf(), mime)
+        assert paths == ["/tmp/a.bin", "/tmp/c.rom"]
+
+    def test_no_urls(self):
+        mime = QMimeData()
+        mime.setText("just text")
+        paths = MainWindow._get_drop_file_paths(_FakeSelf(), mime)
+        assert paths == []
+
+    def test_empty_urls(self):
+        mime = QMimeData()
+        mime.setUrls([])
+        paths = MainWindow._get_drop_file_paths(_FakeSelf(), mime)
+        assert paths == []
+
+
+class TestDropExtensions:
+    """Verify the extension set matches the File > Open dialog."""
+
+    def test_bin_in_extensions(self):
+        assert ".bin" in MainWindow._DROP_EXTENSIONS
+
+    def test_rom_in_extensions(self):
+        assert ".rom" in MainWindow._DROP_EXTENSIONS
+
+    def test_no_unexpected_extensions(self):
+        # Should only accept .bin and .rom
+        assert MainWindow._DROP_EXTENSIONS == {".bin", ".rom"}


### PR DESCRIPTION
## Summary
- Drag `.bin` or `.rom` files onto the main window to open them
- Visual overlay indicates the drop zone during drag-over
- Invalid file types are rejected with a descriptive error message

## Test plan
- [x] Unit tests in `tests/test_drag_drop.py`
- [x] All 537 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)