### PR TITLE
fix: soften battery voltage warning for Read ROM

### DIFF
--- a/.claude/notes.md
+++ b/.claude/notes.md
@@ -18,6 +18,9 @@
 ## Recent Completed Work (Mar 27, 2026) - Drag-and-Drop
 - **Drag-and-drop ROM files** — Users can drag `.bin`/`.rom` files onto the main window to open them. Translucent blue overlay with dashed border shows during drag-over. Invalid file types show a descriptive error. Multiple files supported. Reuses existing open-file flow. 11 tests in `test_drag_drop.py`. (#20)
 
+## Recent Completed Work (Mar 27, 2026) - Issue #21 Fix
+- **Battery voltage warning differentiated by operation** — Read ROM now shows a softer "communication timeouts" message instead of "bricking" warning. Flash operations keep the strong warning. (#21)
+
 ## Recent Completed Work (Mar 26, 2026) - Build Fix
 - **J2534 bridge frozen-app fix** — PyInstaller builds failed to load 32-bit DLL because frozen ctypes raises a different OSError than native bitness mismatch. Bridge fallback now detects both.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to NC Flash are documented here.
 ### Fixed
 - **`Thinking-pad.md` still tracked** — Stash/pop cycle during rebase re-added the file; now properly removed from git tracking
 
+## [v2.3.1] - 2026-03-27
+
+### Fixed
+- **Battery voltage warning too severe for Read ROM** — Read ROM now shows a softer "communication timeouts" warning instead of the "bricking" language used for flash operations, since a failed read is safely retryable (#21)
+
 ## [v2.3.0] - 2026-03-26
 
 ### Added
@@ -27,7 +32,7 @@ All notable changes to NC Flash are documented here.
 - **"ROMs are identical" is no longer an error** — Dynamic flash with no differences shows "Nothing to flash" in grey instead of a red error with traceback
 
 ### Fixed
-- **J2534 bridge not loading in built exe** — PyInstaller frozen builds threw a different OSError than expected, bypassing the 32-bit bridge fallback
+- **J2534 bridge not loading in built exe** — PyInstaller frozen builds threw a different OSError than expected, bypassing the 32-bit bridge fallback. The DLL loader now detects both native bitness mismatch and PyInstaller's frozen-app errors
 - **J2534 bridge exe not found in built app** — PyInstaller puts data files in `_internal/` (sys._MEIPASS) but bridge lookup only searched next to the exe
 - **J2534 bridge console window visible** — The 32-bit bridge subprocess no longer opens a visible cmd window on Windows
 - **DTC count discrepancy** — Activity log showed raw DTC count (with duplicates) while UI showed deduplicated count. Log now shows both (e.g., "Read 15 DTCs (7 unique)")

--- a/src/ui/ecu_window.py
+++ b/src/ui/ecu_window.py
@@ -610,16 +610,33 @@ class ECUProgrammingWindow(QMainWindow):
 
     # --- Flash Operations ---
 
-    def _check_voltage_warning(self) -> bool:
-        """Warn if battery voltage is low. Returns True if OK to proceed."""
+    def _check_voltage_warning(self, operation: str = "flash") -> bool:
+        """Warn if battery voltage is low. Returns True if OK to proceed.
+
+        Args:
+            operation: ``"flash"`` (default) shows a strong bricking warning;
+                       ``"read"`` shows a softer timeout-only warning.
+        """
         if self._voltage is not None and self._voltage < BATTERY_VOLTAGE_WARNING:
+            if operation == "read":
+                message = (
+                    f"Battery voltage is {self._voltage:.1f}V "
+                    f"(recommended: {BATTERY_VOLTAGE_WARNING}V+).\n\n"
+                    "Low voltage may cause communication timeouts.\n"
+                    "You can safely retry if the read fails.\n\n"
+                    "Proceed anyway?"
+                )
+            else:
+                message = (
+                    f"Battery voltage is {self._voltage:.1f}V "
+                    f"(recommended: {BATTERY_VOLTAGE_WARNING}V+).\n\n"
+                    "Low voltage risks bricking the ECU during flash.\n"
+                    "Proceed anyway?"
+                )
             reply = QMessageBox.warning(
                 self,
                 "Low Battery Voltage",
-                f"Battery voltage is {self._voltage:.1f}V "
-                f"(recommended: {BATTERY_VOLTAGE_WARNING}V+).\n\n"
-                "Low voltage risks bricking the ECU during flash/read.\n"
-                "Proceed anyway?",
+                message,
                 QMessageBox.Yes | QMessageBox.No,
                 QMessageBox.No,
             )
@@ -700,7 +717,7 @@ class ECUProgrammingWindow(QMainWindow):
     def _on_read_rom(self):
         self._ecu_busy = True
         self._update_action_states()
-        if not self._check_voltage_warning():
+        if not self._check_voltage_warning(operation="read"):
             self._ecu_busy = False
             self._update_action_states()
             return


### PR DESCRIPTION
## Summary
- Read ROM now shows a softer "communication timeouts" warning instead of the "bricking" language used for flash operations
- A failed read is safely retryable, so the severe warning was misleading

## Test plan
- [x] All 537 tests passing
- [x] Visually verified warning message text

🤖 Generated with [Claude Code](https://claude.com/claude-code)