### PR TITLE
fix: PermissionError when installed for all users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to NC Flash are documented here.
 ### Fixed
 - **`Thinking-pad.md` still tracked** — Stash/pop cycle during rebase re-added the file; now properly removed from git tracking
 
+## [v2.3.2] - 2026-03-28
+
+### Fixed
+- **PermissionError when installed for all users** — Session logs and auto-saved ROM reads were written to the app install directory (`Path(__file__).parent`), which is read-only under `C:\Program Files`. Both now write to `~/.nc-flash/` (logs → `~/.nc-flash/logs/`, reads → `~/.nc-flash/reads/`)
+
 ## [v2.3.1] - 2026-03-27
 
 ### Fixed
@@ -21,7 +26,7 @@ All notable changes to NC Flash are documented here.
 - **ECU Connect/Disconnect** — New menu actions in ECU menu to establish and hold a persistent J2534 connection. Operations reuse the open device instead of reconnecting each time. Status bar shows real connection state
 - **OBD-II PID reading** — Battery voltage (PID 0x42) and engine RPM (PID 0x0C) via standard OBD-II Service 0x01
 - **J2534 32-bit bridge** — Subprocess bridge for 64-bit Python to talk to 32-bit J2534 DLLs, with auto-build in dev mode
-- **Per-session log files** — Each app launch saves a complete log to `./logs/` directory
+- **Per-session log files** — Each app launch saves a complete log to `~/.nc-flash/logs/` directory
 - **UDS log direction prefixes** — Protocol log messages now show `ECU >>` or `Tool >>` to indicate who is speaking
 - **Window geometry persistence** — Main window remembers its position and size between sessions
 - **CI: private _secure module** — CI and release workflows now pull the private `nc-flash-secure` repo so security tests run and release builds include the secure module

--- a/main.py
+++ b/main.py
@@ -2004,10 +2004,11 @@ def main():
         level=logging.INFO, log_file=str(log_file), console=True, detailed=False
     )
 
-    # Per-session log in ./logs/ directory
+    # Per-session log in user-writable directory
+    # (avoid Path(__file__).parent which is read-only under C:\Program Files)
     from datetime import datetime
 
-    session_log_dir = Path(__file__).parent / "logs"
+    session_log_dir = Path.home() / ".nc-flash" / "logs"
     session_log_dir.mkdir(exist_ok=True)
     session_log_name = datetime.now().strftime("%Y-%m-%d_%H%M%S") + ".log"
     session_handler = logging.FileHandler(

--- a/src/ui/ecu_window.py
+++ b/src/ui/ecu_window.py
@@ -894,10 +894,11 @@ class ECUProgrammingWindow(QMainWindow):
         if rom_id.upper().endswith(".HEX"):
             rom_id = rom_id[:-4]
 
-        project_root = Path(__file__).resolve().parent.parent.parent
+        auto_save_dir = Path.home() / ".nc-flash" / "reads"
+        auto_save_dir.mkdir(parents=True, exist_ok=True)
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         file_name = f"{rom_id}_{timestamp}.bin"
-        save_path = project_root / file_name
+        save_path = auto_save_dir / file_name
         try:
             save_path.write_bytes(rom_data)
             logger.info("ROM auto-saved to %s", save_path)


### PR DESCRIPTION
## Summary
- Session logs and auto-saved ROM reads were written to the app install directory (`Path(__file__).parent`), causing `PermissionError: [WinError 5]` when installed under `C:\Program Files`
- Both paths now use `~/.nc-flash/` (logs → `~/.nc-flash/logs/`, reads → `~/.nc-flash/reads/`)

## Test plan
- [ ] Install for all users (puts app under `C:\Program Files\NCFlash`)
- [ ] Launch as a normal (non-admin) user — no PermissionError on startup
- [ ] Read ROM from ECU — auto-saved file appears in `%USERPROFILE%\.nc-flash\reads\`
- [ ] Check `%USERPROFILE%\.nc-flash\logs\` contains session log

🤖 Generated with [Claude Code](https://claude.com/claude-code)