### PR TITLE
fix: force light color scheme for Windows dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to NC Flash are documented here.
 
 ## [Unreleased]
 
+## [v2.3.3] - 2026-03-28
+
 ### Fixed
-- **`Thinking-pad.md` still tracked** — Stash/pop cycle during rebase re-added the file; now properly removed from git tracking
+- **Broken UI on Windows dark theme** — Hardcoded light-theme colors clashed with Windows dark mode system palette, causing unreadable text and selection highlights. App now forces light color scheme via `Qt.ColorScheme.Light`
+
+## [v2.3.2] - 2026-03-28
 
 ## [v2.3.2] - 2026-03-28
 

--- a/main.py
+++ b/main.py
@@ -2025,6 +2025,7 @@ def main():
     logger.info("=" * 60)
 
     app = QApplication(sys.argv)
+    app.styleHints().setColorScheme(Qt.ColorScheme.Light)
     app.setApplicationName(APP_NAME)
 
     window = MainWindow()


### PR DESCRIPTION
## Summary
- Forces `Qt.ColorScheme.Light` at app startup so the UI renders correctly regardless of Windows theme setting
- All hardcoded colors in the codebase assume a light background — Windows dark mode caused unreadable text and broken selection highlights

## Test plan
- [ ] Enable Windows dark mode (Settings > Personalization > Colors > Dark)
- [ ] Launch NC Flash — UI should render with light background, readable text
- [ ] Check table viewer, compare window, settings dialog, ECU window

🤖 Generated with [Claude Code](https://claude.com/claude-code)