### PR TITLE
fix: DTC toggle switch not showing on Windows 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to NC Flash are documented here.
 
 ## [Unreleased]
 
+### Fixed
+- **DTC toggle switch not showing on Windows 10 (#32)** — Window auto-sizing was based on the hidden table widget's tiny 1-cell dimensions, leaving no room for the toggle container. Now sizes from the toggle's own size hint when in toggle mode
+- **DTC toggle animates on window open** — Toggle switch now snaps to its initial position immediately instead of visually sliding into place when the window opens
+
+### Changed
+- Toggle switch shows a pointing-hand cursor on hover for better click affordance
+- Toggle switch clears its background before painting for consistent rendering across Windows versions
+
 ## [v2.4.1] - 2026-03-29
 
 ### Fixed

--- a/src/ui/table_viewer_window.py
+++ b/src/ui/table_viewer_window.py
@@ -647,45 +647,50 @@ class TableViewerWindow(QMainWindow):
         Uses Qt header.length() for reliable column/row totals.
         resize() sets the client area — the OS title bar sits outside it.
         """
-        table_widget = self.viewer.table_widget
-
-        # Total width/height of all table columns/rows (reliable Qt API)
-        table_w = table_widget.horizontalHeader().length()
-        table_h = table_widget.verticalHeader().length()
-
-        # Add visible header sizes
-        if table_widget.verticalHeader().isVisible():
-            table_w += table_widget.verticalHeader().width()
-        if table_widget.horizontalHeader().isVisible():
-            table_h += table_widget.horizontalHeader().height()
-
-        # Table frame border (e.g. 1px per side)
-        table_w += table_widget.frameWidth() * 2
-        table_h += table_widget.frameWidth() * 2
-
-        # Reserve space for scrollbars — they appear dynamically (AsNeeded
-        # policy) and eat into the viewport, which can cascade: a vertical
-        # scrollbar reduces viewport width, triggering a horizontal scrollbar
-        # that reduces viewport height, etc.  Always reserving avoids this.
-        table_w += table_widget.verticalScrollBar().sizeHint().width()
-        table_h += table_widget.horizontalScrollBar().sizeHint().height()
-
-        # Safety padding — scrollbar sizeHint() can underreport the actual
-        # rendered size (especially on high-DPI or themed systems).  Add
-        # one row/column as buffer so content is never clipped behind a
-        # scrollbar, preventing unnecessary scrollbar appearance.
-        if table_widget.rowCount() > 0:
-            table_h += table_widget.rowHeight(0) - 10
+        # Toggle mode: size for the toggle container, not the hidden table
+        if self.viewer.toggle_container.isVisible():
+            toggle_hint = self.viewer.toggle_container.sizeHint()
+            content_w = max(toggle_hint.width(), 120)
+            content_h = toggle_hint.height()
         else:
-            table_h += 14
-        if table_widget.columnCount() > 0:
-            table_w += table_widget.columnWidth(0) - 20
-        else:
-            table_w += 40
+            table_widget = self.viewer.table_widget
 
-        # Build client area from layout components
-        content_w = table_w
-        content_h = table_h
+            # Total width/height of all table columns/rows (reliable Qt API)
+            table_w = table_widget.horizontalHeader().length()
+            table_h = table_widget.verticalHeader().length()
+
+            # Add visible header sizes
+            if table_widget.verticalHeader().isVisible():
+                table_w += table_widget.verticalHeader().width()
+            if table_widget.horizontalHeader().isVisible():
+                table_h += table_widget.horizontalHeader().height()
+
+            # Table frame border (e.g. 1px per side)
+            table_w += table_widget.frameWidth() * 2
+            table_h += table_widget.frameWidth() * 2
+
+            # Reserve space for scrollbars — they appear dynamically (AsNeeded
+            # policy) and eat into the viewport, which can cascade: a vertical
+            # scrollbar reduces viewport width, triggering a horizontal scrollbar
+            # that reduces viewport height, etc.  Always reserving avoids this.
+            table_w += table_widget.verticalScrollBar().sizeHint().width()
+            table_h += table_widget.horizontalScrollBar().sizeHint().height()
+
+            # Safety padding — scrollbar sizeHint() can underreport the actual
+            # rendered size (especially on high-DPI or themed systems).  Add
+            # one row/column as buffer so content is never clipped behind a
+            # scrollbar, preventing unnecessary scrollbar appearance.
+            if table_widget.rowCount() > 0:
+                table_h += table_widget.rowHeight(0) - 10
+            else:
+                table_h += 14
+            if table_widget.columnCount() > 0:
+                table_w += table_widget.columnWidth(0) - 20
+            else:
+                table_w += 40
+
+            content_w = table_w
+            content_h = table_h
 
         # Y-axis label (left of table, in horizontal layout with 2px spacing)
         if self.viewer.y_axis_label.isVisible():

--- a/src/ui/widgets/toggle_switch.py
+++ b/src/ui/widgets/toggle_switch.py
@@ -25,6 +25,7 @@ class ToggleSwitch(QAbstractButton):
         super().__init__(parent)
         self.setCheckable(True)
         self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        self.setCursor(Qt.PointingHandCursor)
 
         self._handle_position = self._HANDLE_MARGIN
 
@@ -47,38 +48,41 @@ class ToggleSwitch(QAbstractButton):
 
     handle_position = Property(float, _get_handle_position, _set_handle_position)
 
-    def setChecked(self, checked):
-        super().setChecked(checked)
-        # Snap position immediately (no animation) when set programmatically
+    def _target_position(self, checked):
+        """Return the handle position for a given checked state"""
         if checked:
-            self._handle_position = (
-                self._TRACK_WIDTH - self._HANDLE_SIZE - self._HANDLE_MARGIN
-            )
-        else:
-            self._handle_position = self._HANDLE_MARGIN
+            return self._TRACK_WIDTH - self._HANDLE_SIZE - self._HANDLE_MARGIN
+        return self._HANDLE_MARGIN
+
+    def setChecked(self, checked):
+        """Set checked state and snap handle immediately (no animation)"""
+        self._animation.stop()
+        super().setChecked(checked)
+        self._handle_position = self._target_position(checked)
         self.update()
 
     def checkStateSet(self):
+        """Called by Qt when checked state changes via setChecked — no animation needed"""
         super().checkStateSet()
-        self._animate_toggle()
 
     def nextCheckState(self):
+        """Called by Qt on user click — animate the toggle"""
+        old_pos = self._handle_position
         super().nextCheckState()
-        self._animate_toggle()
-
-    def _animate_toggle(self):
+        # C++ setChecked() doesn't call our Python override, so compute
+        # the target from the new checked state directly
+        end_pos = self._target_position(self.isChecked())
         self._animation.stop()
-        if self.isChecked():
-            end = self._TRACK_WIDTH - self._HANDLE_SIZE - self._HANDLE_MARGIN
-        else:
-            end = self._HANDLE_MARGIN
-        self._animation.setStartValue(self._handle_position)
-        self._animation.setEndValue(end)
+        self._animation.setStartValue(old_pos)
+        self._animation.setEndValue(end_pos)
         self._animation.start()
 
     def paintEvent(self, event):
         painter = QPainter(self)
         painter.setRenderHint(QPainter.Antialiasing)
+
+        # Clear background for consistent rendering across platforms
+        painter.eraseRect(self.rect())
 
         # Draw track
         if self.isChecked():


### PR DESCRIPTION
## Summary
- **Window sizing fix (#32):** `_auto_size_window()` was calculating size from the hidden table widget's tiny 1-cell dimensions, leaving no room for the toggle container. Now uses the toggle container's `sizeHint()` when in toggle mode
- **Toggle animation on open:** Toggle switch now snaps to its initial position immediately instead of visually sliding into place
- **Cross-platform rendering:** Added `eraseRect()` before custom painting and pointing-hand cursor for click affordance

Closes #32

## Test plan
- [x] All 573 tests pass
- [ ] Open a DTC Activation Flag table — toggle should appear in position without animation
- [ ] Click the toggle — should animate smoothly between ON/OFF
- [ ] Verify on Windows 10 if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)