### PR TITLE
fix: Save As breaks future saves and edits (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to NC Flash are documented here.
 - **Auto-round setting** — New checkbox in Settings > Editor to automatically round interpolation and smoothing results one decimal level coarser than the table's display format
 
 ### Fixed
+- **Save As breaks future saves and edits** — After using Save As, the internal ROM path was not updated, causing all subsequent table opens and saves to fail with "No document found for rom_path=..." (#34)
 - **DTC codes don't match RomDrop** — Live DTC reading returned garbage codes (e.g. P03C1 instead of C0121) due to two bugs: the KWP2000 response count byte was not skipped, misaligning all DTC parsing; and chassis codes (C-codes) used standard OBD-II keys (0x4xxx) instead of Mazda NC's actual encoding (0xCxxx)
 
 ## [v2.3.3] - 2026-03-28

--- a/main.py
+++ b/main.py
@@ -1111,8 +1111,36 @@ class MainWindow(
 
         if file_path:
             try:
+                # Capture old path before save updates it
+                old_rom_path = document.rom_reader.rom_path
+
                 document.save(file_path)
                 document.set_modified(False)
+
+                # Migrate tracking dicts from old path to new path
+                new_rom_path = document.rom_reader.rom_path
+                if old_rom_path != new_rom_path:
+                    for d in (
+                        self.modified_cells,
+                        self.original_table_values,
+                        self.rom_colors,
+                    ):
+                        if old_rom_path in d:
+                            d[new_rom_path] = d.pop(old_rom_path)
+
+                    # Update rom_path on any open table viewer windows
+                    for window in self.open_table_windows:
+                        if window.rom_path == old_rom_path:
+                            window.rom_path = new_rom_path
+
+                    # Migrate undo stacks and pending changes
+                    # (keyed by composite table keys)
+                    if document.rom_reader.definition:
+                        for table in document.rom_reader.definition.tables:
+                            old_key = make_table_key(old_rom_path, table.address)
+                            new_key = make_table_key(new_rom_path, table.address)
+                            self.table_undo_manager.rename_key(old_key, new_key)
+                            self.change_tracker.rename_key(old_key, new_key)
 
                 # Update tab title with new filename
                 self._update_tab_title(document)

--- a/src/core/change_tracker.py
+++ b/src/core/change_tracker.py
@@ -399,6 +399,11 @@ class ChangeTracker:
         self._notify_change()
         logger.debug("Cleared pending changes")
 
+    def rename_key(self, old_key: str, new_key: str):
+        """Rename a pending-changes key (e.g., after Save As changes the ROM path)."""
+        if old_key in self._pending:
+            self._pending[new_key] = self._pending.pop(old_key)
+
     def clear_pending_for_keys(self, keys):
         """Clear pending changes for specific composite keys (e.g., when closing a ROM)."""
         removed = 0

--- a/src/core/table_undo_manager.py
+++ b/src/core/table_undo_manager.py
@@ -173,6 +173,11 @@ class TableUndoManager:
         for key in list(keys):
             self.remove_stack(key)
 
+    def rename_key(self, old_key: str, new_key: str):
+        """Rename a stack key (e.g., after Save As changes the ROM path)."""
+        if old_key in self._stacks:
+            self._stacks[new_key] = self._stacks.pop(old_key)
+
     def clear_stack(self, table_key: str):
         """Clear the undo stack for a specific table."""
         if table_key in self._stacks:

--- a/src/ui/rom_document.py
+++ b/src/ui/rom_document.py
@@ -103,9 +103,10 @@ class RomDocument(QWidget):
         save_path = file_path if file_path else self.rom_path
         self.rom_reader.save_rom(save_path)
 
-        # Update path if it changed
+        # Update path if it changed (Save As)
         if file_path:
             self.rom_path = file_path
             self.file_name = Path(file_path).name
+            self.rom_reader.rom_path = Path(file_path)
 
         self.set_modified(False)

--- a/tests/test_change_tracker.py
+++ b/tests/test_change_tracker.py
@@ -230,3 +230,40 @@ def test_change_callbacks(tracker, sample_table):
 
     # Callback shouldn't be called after removal
     assert callback_count[0] == 1
+
+
+def test_rename_key(tracker, sample_table):
+    """Test that rename_key migrates pending changes to the new key"""
+    from src.core.table_undo_manager import make_table_key
+
+    old_rom_path = "C:/old/rom.bin"
+    new_rom_path = "C:/new/rom.bin"
+
+    tracker.record_pending_change(
+        table=sample_table,
+        row=0,
+        col=0,
+        old_value=10.0,
+        new_value=20.0,
+        old_raw=100,
+        new_raw=200,
+        rom_path=old_rom_path,
+    )
+
+    old_key = make_table_key(old_rom_path, sample_table.address)
+    new_key = make_table_key(new_rom_path, sample_table.address)
+
+    assert old_key in tracker._pending
+    assert new_key not in tracker._pending
+
+    tracker.rename_key(old_key, new_key)
+
+    assert old_key not in tracker._pending
+    assert new_key in tracker._pending
+    assert tracker._pending[new_key].has_changes()
+
+
+def test_rename_key_noop_if_missing(tracker):
+    """Test that rename_key is a no-op if old key doesn't exist"""
+    tracker.rename_key("nonexistent", "new_key")
+    assert "new_key" not in tracker._pending

--- a/tests/test_rom_reader.py
+++ b/tests/test_rom_reader.py
@@ -423,6 +423,46 @@ class TestRomSaving:
 
         assert test_rom.exists()
 
+    def test_save_as_updates_rom_reader_path(
+        self, sample_rom_path, sample_xml_path, tmp_path
+    ):
+        """Test that RomDocument.save() updates rom_reader.rom_path on Save As"""
+        from src.ui.rom_document import RomDocument
+
+        # Copy ROM to tmp dir so we can modify it
+        test_rom = tmp_path / "original.bin"
+        test_rom.write_bytes(sample_rom_path.read_bytes())
+
+        definition = load_definition(str(sample_xml_path))
+        reader = RomReader(str(test_rom), definition)
+        doc = RomDocument(str(test_rom), definition, reader)
+
+        save_as_path = str(tmp_path / "saved_as.bin")
+        doc.save(save_as_path)
+
+        # rom_reader.rom_path should now point to the new file
+        assert reader.rom_path == Path(save_as_path)
+        assert doc.rom_path == save_as_path
+        assert doc.file_name == "saved_as.bin"
+
+    def test_save_without_path_keeps_rom_reader_path(
+        self, sample_rom_path, sample_xml_path, tmp_path
+    ):
+        """Test that RomDocument.save() without path keeps rom_reader.rom_path unchanged"""
+        from src.ui.rom_document import RomDocument
+
+        test_rom = tmp_path / "keep_path.bin"
+        test_rom.write_bytes(sample_rom_path.read_bytes())
+
+        definition = load_definition(str(sample_xml_path))
+        reader = RomReader(str(test_rom), definition)
+        doc = RomDocument(str(test_rom), definition, reader)
+
+        original_path = reader.rom_path
+        doc.save()  # Save without new path
+
+        assert reader.rom_path == original_path
+
 
 class TestDataIntegrity:
     """Test data integrity during read/write cycle"""


### PR DESCRIPTION
## Summary
- After Save As, `rom_reader.rom_path` was never updated to the new file path
- All tracking dicts (`modified_cells`, `original_table_values`, `rom_colors`), open table viewer windows, undo stacks, and change tracker entries still referenced the old path
- Subsequent table opens failed with `WARNING - No document found for rom_path=<old path>`

## Changes
- `RomDocument.save()` now updates `rom_reader.rom_path` on Save As
- `save_rom_as()` migrates all path-keyed state to the new path
- Added `rename_key()` to `TableUndoManager` and `ChangeTracker`

## Test plan
- [x] 4 new unit tests (rename_key, save-as path update, save keeps path)
- [x] Full test suite passes (575 passed, 26 skipped)
- [x] Manual testing: modify table → Save As → modify again → save works

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)