### PR TITLE
fix: format_value fails on %d and %x integer format specifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to NC Flash are documented here.
 ### Fixed
 - **DTC toggle switch not showing on Windows 10 (#32)** — Window auto-sizing was based on the hidden table widget's tiny 1-cell dimensions, leaving no room for the toggle container. Now sizes from the toggle's own size hint when in toggle mode
 - **DTC toggle animates on window open** — Toggle switch now snaps to its initial position immediately instead of visually sliding into place when the window opens
+- **Tables with `%d` or `%x` format display as `0.00` after editing** — `format_value()` failed on integer/hex format specifiers because Python's `d`/`x` formats reject floats. Now converts to `int` first. Affects 176 scalings using `%d` and 3 using `%08x`
 
 ### Changed
 - Toggle switch shows a pointing-hand cursor on hover for better click affordance

--- a/src/utils/formatting.py
+++ b/src/utils/formatting.py
@@ -32,9 +32,14 @@ def printf_to_python_format(printf_format: str) -> str:
     return result
 
 
+_INT_SPECIFIERS = re.compile(r"[diouxX]$")
+
+
 def format_value(value: float, format_spec: str) -> str:
     """Format a value using a Python format spec with error handling."""
     try:
+        if _INT_SPECIFIERS.search(format_spec):
+            return f"{int(round(value)):{format_spec}}"
         return f"{value:{format_spec}}"
     except (ValueError, TypeError):
         return f"{value:.2f}"


### PR DESCRIPTION
## Summary
- Python's `d`/`x` format codes reject float values, causing `format_value()` to fall back to `.2f` — displaying `0.00` instead of `0` after any edit operation on tables using `%d` (176 scalings) or `%08x` (3 scalings)
- Now detects integer specifiers and converts to `int(round(value))` first

## Test plan
- [x] Full test suite: 577 passed
- [x] Manual test: EGR Target table (`%d` format) — increment/round operations display correctly as integers

🤖 Generated with [Claude Code](https://claude.com/claude-code)