### PR TITLE
feat: clear DTCs from read dialog, widen comparison sidebar

### DIFF
--- a/.claude/notes.md
+++ b/.claude/notes.md
@@ -5,6 +5,10 @@
 - `examples/metadata/LFDJEA.xml` is untracked — may need committing
 - **Review romdrop.crc fallback** — `src/ecu/rom_utils.py:169` silently skips CRC verification if `romdrop.crc` is missing. Patching still proceeds without validation. Need to decide: should patching be blocked without the CRC database, or is a warning sufficient?
 
+## Recent Completed Work (Mar 29, 2026) - Clear DTCs from Read Dialog (#33)
+- **"Clear DTCs" button in read-DTC dialog** — After reading DTCs, the results dialog now shows a "Clear DTCs" button alongside OK. Clicking it sends the clear command immediately without a second confirmation prompt
+- **Extracted `_do_clear_dtcs()` helper** — Shared by both the dialog button and the standalone "Clear DTCs" toolbar button
+
 ## Recent Completed Work (Mar 29, 2026) - Checksum Table Fix (P0601/P0606)
 - **CHECKSUM_TABLE_OFFSET was 0xFF658 — corrected to 0xFF650**: The 8-byte misalignment caused every checksum entry to be misread (checksum field parsed as start address), corrupting all 35 table entries with CHECKSUM_MAGIC before flashing
 - **End address is inclusive, not exclusive**: Table stores last byte of range; fixed `correct_rom_checksums` to pass `end_incl + 1` to `mazda_checksum`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to NC Flash are documented here.
 
 ## [Unreleased]
 
+### Added
+- **Clear DTCs from read dialog (#33)** — After reading DTCs, the results dialog now shows a "Clear DTCs" button alongside OK, allowing immediate clearing without navigating to a separate action
+
 ### Fixed
 - **DTC toggle switch not showing on Windows 10 (#32)** — Window auto-sizing was based on the hidden table widget's tiny 1-cell dimensions, leaving no room for the toggle container. Now sizes from the toggle's own size hint when in toggle mode
 - **DTC toggle animates on window open** — Toggle switch now snaps to its initial position immediately instead of visually sliding into place when the window opens
 - **Tables with `%d` or `%x` format display as `0.00` after editing** — `format_value()` failed on integer/hex format specifiers because Python's `d`/`x` formats reject floats. Now converts to `int` first. Affects 176 scalings using `%d` and 3 using `%08x`
+- **ROM comparison sidebar too narrow** — Sidebar max width increased from 300px to 600px so long table names are not clipped
 
 ### Changed
 - Toggle switch shows a pointing-hand cursor on hover for better click affordance

--- a/src/ui/compare_window.py
+++ b/src/ui/compare_window.py
@@ -586,7 +586,7 @@ class CompareWindow(QMainWindow):
         sidebar_layout.addWidget(self._tree)
 
         self._sidebar.setMinimumWidth(200)
-        self._sidebar.setMaximumWidth(300)
+        self._sidebar.setMaximumWidth(600)
 
     def _build_table_panels(self):
         """Create the two QTableWidget panels with compact labels for side-by-side comparison."""

--- a/src/ui/ecu_window.py
+++ b/src/ui/ecu_window.py
@@ -926,9 +926,15 @@ class ECUProgrammingWindow(QMainWindow):
                 QMessageBox.information(self, "DTCs", "No DTCs stored.")
             else:
                 text = "\n".join(f"  {d.formatted}: {d.description}" for d in unique)
-                QMessageBox.information(
-                    self, "DTCs", f"Found {len(unique)} DTC(s):\n\n{text}"
-                )
+                msg = QMessageBox(self)
+                msg.setIcon(QMessageBox.Information)
+                msg.setWindowTitle("DTCs")
+                msg.setText(f"Found {len(unique)} DTC(s):\n\n{text}")
+                msg.addButton(QMessageBox.Ok)
+                clear_btn = msg.addButton("Clear DTCs", QMessageBox.ActionRole)
+                msg.exec()
+                if msg.clickedButton() == clear_btn:
+                    self._do_clear_dtcs(manager)
             self._card_ecu.set_subtitle(
                 f"DTCs: {len(unique)} stored", "#cc8800" if unique else "#44aa44"
             )
@@ -937,6 +943,17 @@ class ECUProgrammingWindow(QMainWindow):
         finally:
             self._ecu_busy = False
             self._update_action_states()
+
+    def _do_clear_dtcs(self, manager: FlashManager):
+        """Send clear-DTC command and update the UI status card."""
+        try:
+            manager.clear_dtcs(uds=self._session.uds)
+            QMessageBox.information(self, "DTCs Cleared", "All DTCs cleared.")
+            self._dtcs = []
+            self._card_ecu.set_subtitle("DTCs: 0 stored", "#44aa44")
+            logger.info("DTCs cleared")
+        except ECUError as e:
+            QMessageBox.critical(self, "Error", f"Failed to clear DTCs:\n{e}")
 
     def _on_clear_dtcs(self):
         if not self._session or not self._session.uds:
@@ -956,10 +973,7 @@ class ECUProgrammingWindow(QMainWindow):
             return
         try:
             manager = FlashManager(self._get_dll_path())
-            manager.clear_dtcs(uds=self._session.uds)
-            QMessageBox.information(self, "DTCs Cleared", "All DTCs cleared.")
-            self._card_ecu.set_subtitle("DTCs: 0 stored", "#44aa44")
-            logger.info("DTCs cleared")
+            self._do_clear_dtcs(manager)
         except ECUError as e:
             QMessageBox.critical(self, "Error", f"Failed to clear DTCs:\n{e}")
         finally:


### PR DESCRIPTION
## Summary
- **Clear DTCs from read dialog (#33)** — After reading DTCs, the results dialog now shows a "Clear DTCs" button alongside OK, allowing immediate clearing without a separate action
- **ROM comparison sidebar wider** — Max width increased from 300px to 600px so long table names aren't clipped

## Test plan
- [x] Manual test: Read DTCs shows Clear button, clearing works
- [x] Manual test: Comparison window sidebar allows wider resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)