### PR TITLE
feat: add Scan RAM button to ECU window

### DIFF
--- a/.claude/notes.md
+++ b/.claude/notes.md
@@ -5,6 +5,11 @@
 - `examples/metadata/LFDJEA.xml` is untracked — may need committing
 - **Review romdrop.crc fallback** — `src/ecu/rom_utils.py:169` silently skips CRC verification if `romdrop.crc` is missing. Patching still proceeds without validation. Need to decide: should patching be blocked without the CRC database, or is a warning sufficient?
 
+## Recent Completed Work (Mar 29, 2026) - Scan RAM UI
+- **"Scan RAM" button in ECU window** — Exposes the existing `scan_ram()` backend (reads 192 blocks of 0x1F0 bytes from ECU RAM 0x0000-0xBFFF) as a UI button alongside Read ROM and DTCs
+- **Threaded with progress** — Uses `_FlashWorker` pattern with `SCANNING_RAM` state, shows block-by-block progress, abortable
+- **Auto-saves RAM dump** — Saves to `~/.nc-flash/reads/{ROM_ID}_RAM_{timestamp}.bin` and opens Explorer to the file
+
 ## Recent Completed Work (Mar 29, 2026) - Clear DTCs from Read Dialog (#33)
 - **"Clear DTCs" button in read-DTC dialog** — After reading DTCs, the results dialog now shows a "Clear DTCs" button alongside OK. Clicking it sends the clear command immediately without a second confirmation prompt
 - **Extracted `_do_clear_dtcs()` helper** — Shared by both the dialog button and the standalone "Clear DTCs" toolbar button

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to NC Flash are documented here.
 
 ### Added
 - **Clear DTCs from read dialog (#33)** — After reading DTCs, the results dialog now shows a "Clear DTCs" button alongside OK, allowing immediate clearing without navigating to a separate action
+- **Scan RAM button in ECU window** — Reads ECU RAM (0x0000–0xBFFF, 192 blocks) via UDS and saves the dump to `~/.nc-flash/reads/`. Uses the existing session, shows block-by-block progress, and supports abort. Based on romdrop's `uds_ScanRAM`
 
 ### Fixed
 - **DTC toggle switch not showing on Windows 10 (#32)** — Window auto-sizing was based on the hidden table widget's tiny 1-cell dimensions, leaving no room for the toggle container. Now sizes from the toggle's own size hint when in toggle mode

--- a/src/ecu/flash_manager.py
+++ b/src/ecu/flash_manager.py
@@ -67,6 +67,7 @@ class FlashState(Enum):
     CONNECTING = "connecting"
     AUTHENTICATING = "authenticating"
     READING = "reading"
+    SCANNING_RAM = "scanning_ram"
     PREPARING_SBL = "preparing_sbl"
     TRANSFERRING_SBL = "transferring_sbl"
     TRANSFERRING_PROGRAM = "transferring_program"
@@ -83,12 +84,19 @@ _TRANSITIONS = {
     FlashState.CONNECTING: {FlashState.AUTHENTICATING, FlashState.ERROR},
     # Flash path: AUTHENTICATING -> PREPARING_SBL
     # Read path:  AUTHENTICATING -> READING
+    # Scan path:  AUTHENTICATING -> SCANNING_RAM
     FlashState.AUTHENTICATING: {
         FlashState.PREPARING_SBL,
         FlashState.READING,
+        FlashState.SCANNING_RAM,
         FlashState.ERROR,
     },
     FlashState.READING: {FlashState.COMPLETE, FlashState.ERROR, FlashState.ABORTED},
+    FlashState.SCANNING_RAM: {
+        FlashState.COMPLETE,
+        FlashState.ERROR,
+        FlashState.ABORTED,
+    },
     FlashState.PREPARING_SBL: {FlashState.TRANSFERRING_SBL, FlashState.ERROR},
     FlashState.TRANSFERRING_SBL: {
         FlashState.TRANSFERRING_PROGRAM,
@@ -801,45 +809,59 @@ class FlashManager:
     def scan_ram(self, uds=None, progress_cb=None) -> bytearray:
         """Scan ECU RAM (0x0000-0xBFFF) and return contents.
 
+        Uses the borrowed session (via use_session()) when available,
+        otherwise opens a new J2534 connection.
+
         Args:
-            uds: Optional UDSConnection from an active session.
-                 Note: security access is still needed and will be
-                 performed on the provided connection.
+            uds: Optional UDSConnection from an active session
+                 (legacy direct-call path; the UI uses use_session()).
+            progress_cb: Callback receiving (current_block, total_blocks).
         """
+        if self.is_busy:
+            raise FlashError("Operation already in progress")
+
+        self._abort_event.clear()
+        self._state = FlashState.IDLE
+
         try:
-            if uds:
-                uds.diagnostic_session()
-                seed = uds.security_access_request_seed()
-                if not SECURE_MODULE_AVAILABLE:
-                    raise SecureModuleNotAvailable()
-                key = compute_security_key(seed)
-                uds.security_access_send_key(key)
-                return uds.scan_ram(progress_callback=progress_cb)
+            self._connect(progress_cb)
+            self._authenticate(progress_cb)
 
-            from .j2534 import J2534Device, setup_isotp_flow_control
-            from .protocol import UDSConnection
-            from .constants import ISO15765_BS, ISO15765_STMIN
+            self._set_state(FlashState.SCANNING_RAM)
 
-            with J2534Device(self._dll_path) as device:
-                channel_id = device.connect(J2534_PROTOCOL_ISO15765, 0, CAN_BAUDRATE)
-                device.set_config(channel_id, {ISO15765_BS: 0, ISO15765_STMIN: 0})
-                setup_isotp_flow_control(device, channel_id)
+            total_blocks = 192  # 0xC0
+            block_size = 0x1F0
+            ram = bytearray(total_blocks * block_size)
 
-                uds_conn = UDSConnection(device, channel_id)
-                uds_conn.tester_present()
-                uds_conn.diagnostic_session()
-                seed = uds_conn.security_access_request_seed()
+            for i in range(total_blocks):
+                if self._check_abort():
+                    raise FlashAbortedError("RAM scan aborted by user")
 
-                if not SECURE_MODULE_AVAILABLE:
-                    raise SecureModuleNotAvailable()
-                key = compute_security_key(seed)
-                uds_conn.security_access_send_key(key)
+                address = i * block_size
+                data = self._uds.read_memory_by_address(address, block_size)
+                ram[address : address + len(data)] = data
+                pct = ((i + 1) / total_blocks) * 100.0
+                self._notify(
+                    progress_cb,
+                    f"Scanning RAM: block {i + 1}/{total_blocks}",
+                    percent=pct,
+                    bytes_sent=(i + 1) * block_size,
+                    bytes_total=total_blocks * block_size,
+                )
 
-                return uds_conn.scan_ram(progress_callback=progress_cb)
+            self._set_state(FlashState.COMPLETE)
+            return ram
+        except FlashAbortedError:
+            self._set_state(FlashState.ABORTED)
+            raise
         except ECUError:
+            self._set_state(FlashState.ERROR)
             raise
         except Exception as e:
+            self._set_state(FlashState.ERROR)
             raise FlashError(f"Failed to scan RAM: {e}") from e
+        finally:
+            self._cleanup()
 
     def sniff_can(self, duration_seconds: int = 20, progress_cb=None) -> bytes:
         """

--- a/src/ui/ecu_window.py
+++ b/src/ui/ecu_window.py
@@ -87,6 +87,10 @@ class _FlashWorker(QObject):
                 self._result = self._manager.read_rom(
                     progress_cb=self._on_progress,
                 )
+            elif self._operation == "scan_ram":
+                self._result = self._manager.scan_ram(
+                    progress_cb=self._on_progress,
+                )
             self.finished.emit()
         except FlashAbortedError:
             self.error.emit("Operation aborted by user")
@@ -280,6 +284,11 @@ class ECUProgrammingWindow(QMainWindow):
         self._btn_clear_dtcs.setMinimumHeight(36)
         self._btn_clear_dtcs.clicked.connect(self._on_clear_dtcs)
         row.addWidget(self._btn_clear_dtcs)
+
+        self._btn_scan_ram = QPushButton("Scan RAM")
+        self._btn_scan_ram.setMinimumHeight(36)
+        self._btn_scan_ram.clicked.connect(self._on_scan_ram)
+        row.addWidget(self._btn_scan_ram)
 
         actions_layout.addLayout(row)
         self._stack.addWidget(actions_page)
@@ -552,6 +561,7 @@ class ECUProgrammingWindow(QMainWindow):
             self._btn_clear_dtcs.setEnabled(False)
             self._btn_full_flash.setEnabled(False)
             self._btn_read_rom.setEnabled(False)
+            self._btn_scan_ram.setEnabled(False)
             self._btn_flash_current.setEnabled(False)
             return
 
@@ -559,9 +569,10 @@ class ECUProgrammingWindow(QMainWindow):
         self._btn_read_dtcs.setEnabled(bool(connected))
         self._btn_clear_dtcs.setEnabled(bool(connected))
 
-        # Read ROM: needs safe conditions + secure module
+        # Read ROM / Scan RAM: needs safe conditions + secure module
         can_read = safe_conditions and SECURE_MODULE_AVAILABLE
         self._btn_read_rom.setEnabled(bool(can_read))
+        self._btn_scan_ram.setEnabled(bool(can_read))
 
         # Flash: needs safe conditions + secure module + ROM loaded
         can_flash = safe_conditions and SECURE_MODULE_AVAILABLE
@@ -597,6 +608,7 @@ class ECUProgrammingWindow(QMainWindow):
             tip = ""
         self._btn_full_flash.setToolTip(tip)
         self._btn_read_rom.setToolTip(tip)
+        self._btn_scan_ram.setToolTip(tip)
         self._btn_flash_current.setToolTip(tip)
 
     def _get_current_rom_data(self) -> bytes | None:
@@ -723,6 +735,15 @@ class ECUProgrammingWindow(QMainWindow):
             return
         self._start_flash("read")
 
+    def _on_scan_ram(self):
+        self._ecu_busy = True
+        self._update_action_states()
+        if not self._check_voltage_warning(operation="read"):
+            self._ecu_busy = False
+            self._update_action_states()
+            return
+        self._start_flash("scan_ram")
+
     def _start_flash(self, operation: str, **kwargs):
         """Start a flash/read operation with inline progress."""
         self._poll_timer.stop()
@@ -732,9 +753,10 @@ class ECUProgrammingWindow(QMainWindow):
         self._progress_state.setText("Preparing...")
         self._progress_state.setStyleSheet("font-weight: bold; font-size: 13px;")
         self._progress_detail.setText("")
-        # Only allow abort during read — aborting a flash risks bricking the ECU
-        self._btn_abort.setEnabled(operation == "read")
-        self._btn_abort.setVisible(operation == "read")
+        # Only allow abort during read-only ops — aborting a flash risks bricking the ECU
+        allow_abort = operation in ("read", "scan_ram")
+        self._btn_abort.setEnabled(allow_abort)
+        self._btn_abort.setVisible(allow_abort)
         self._btn_done.setVisible(False)
 
         manager = FlashManager(self._get_dll_path())
@@ -802,6 +824,7 @@ class ECUProgrammingWindow(QMainWindow):
                 "flash",
                 "dynamic_flash",
                 "read",
+                "scan_ram",
             )
             self._session.release(connection_dead=connection_dead)
 
@@ -840,6 +863,23 @@ class ECUProgrammingWindow(QMainWindow):
                 else:
                     self._progress_detail.setText("ROM save failed. Reconnecting...")
                 # ECU is stuck in programming session — must reconnect
+                QTimer.singleShot(500, self._auto_reconnect)
+            elif self._current_operation == "scan_ram" and worker.result:
+                saved_path = self._auto_save_ram_dump(worker.result)
+                if saved_path:
+                    self._progress_detail.setText(
+                        f"RAM dump saved to {saved_path.name}. Reconnecting..."
+                    )
+                    try:
+                        import subprocess
+
+                        subprocess.Popen(["explorer", "/select,", str(saved_path)])
+                    except Exception:
+                        pass
+                else:
+                    self._progress_detail.setText(
+                        "RAM dump save failed. Reconnecting..."
+                    )
                 QTimer.singleShot(500, self._auto_reconnect)
             elif self._current_operation in ("flash", "dynamic_flash"):
                 self._progress_detail.setText("Flash complete! ECU is rebooting...")
@@ -905,6 +945,29 @@ class ECUProgrammingWindow(QMainWindow):
             return save_path
         except Exception as e:
             logger.error("Failed to auto-save ROM: %s", e)
+            return None
+
+    def _auto_save_ram_dump(self, ram_data: bytearray) -> Path | None:
+        """Auto-save RAM dump to ~/.nc-flash/reads/ as {ROM_ID}_RAM_{timestamp}.bin."""
+        from datetime import datetime
+
+        rom_id = self._card_ecu.get_value().strip()
+        if not rom_id or rom_id == "—":
+            rom_id = "ecu"
+        if rom_id.upper().endswith(".HEX"):
+            rom_id = rom_id[:-4]
+
+        auto_save_dir = Path.home() / ".nc-flash" / "reads"
+        auto_save_dir.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        file_name = f"{rom_id}_RAM_{timestamp}.bin"
+        save_path = auto_save_dir / file_name
+        try:
+            save_path.write_bytes(ram_data)
+            logger.info("RAM dump saved to %s (%d bytes)", save_path, len(ram_data))
+            return save_path
+        except Exception as e:
+            logger.error("Failed to save RAM dump: %s", e)
             return None
 
     # --- DTC Operations ---

--- a/tests/test_ecu_flash_manager.py
+++ b/tests/test_ecu_flash_manager.py
@@ -21,6 +21,7 @@ class TestFlashState:
             "connecting",
             "authenticating",
             "reading",
+            "scanning_ram",
             "preparing_sbl",
             "transferring_sbl",
             "transferring_program",


### PR DESCRIPTION
## Summary
- Exposes the existing `scan_ram()` backend (UDS `ReadMemoryByAddress` over 0x0000–0xBFFF) as a "Scan RAM" button in the ECU window
- Uses the borrowed session via `_connect()` / `_authenticate()` (same pattern as Read ROM), with block-by-block `FlashProgress` updates and abort support
- Auto-saves RAM dump to `~/.nc-flash/reads/{ROM_ID}_RAM_{timestamp}.bin` and opens Explorer to the file

## Test plan
- [x] All 592 tests pass
- [x] Verified on hardware — scan completes and saves dump file

🤖 Generated with [Claude Code](https://claude.com/claude-code)