### PR TITLE
fix: remove RomDrop notice from UI (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to NC Flash are documented here.
 - **ROM comparison sidebar too narrow** — Sidebar max width increased from 300px to 600px so long table names are not clipped
 
 ### Changed
+- **Remove RomDrop references from UI (#39)** — About dialog and README now say "Native ECU flashing via J2534/UDS" instead of referencing RomDrop, reflecting the current native flashing support
 - Toggle switch shows a pointing-hand cursor on hover for better click affordance
 - Toggle switch clears its background before painting for consistent rendering across Windows versions
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ python main.py
 - Multi-window table viewers
 - Recent files list
 - Session restoration (automatically reopen last ROM)
-- First-run setup wizard for RomDrop configuration
+- First-run setup wizard for metadata configuration
 - Configurable settings (font size, color maps, export paths)
 - Scaling property editor for table definitions
 - Verbose activity log console
@@ -212,7 +212,7 @@ nc-flash/
 │   │   ├── history_viewer.py          # Version history dialog
 │   │   ├── commit_dialog.py           # Commit creation dialog
 │   │   ├── project_wizard.py          # New project wizard
-│   │   ├── setup_wizard.py            # First-run RomDrop setup
+│   │   ├── setup_wizard.py            # First-run metadata setup
 │   │   ├── settings_dialog.py         # Settings/preferences
 │   │   ├── scaling_edit_dialog.py     # Scaling property editor
 │   │   ├── data_operation_dialogs.py  # Add/Multiply/Set dialogs
@@ -333,7 +333,7 @@ Tests run automatically on GitHub Actions for:
 
 **Current Version:** v2.3.0
 
-Full table editing, project management with version history, interactive graph visualization, ROM comparison tool, toolbar-driven UI, AI assistant integration via MCP server, and ECU flashing via RomDrop.
+Full table editing, project management with version history, interactive graph visualization, ROM comparison tool, toolbar-driven UI, AI assistant integration via MCP server, and native ECU flashing via J2534/UDS.
 
 ## Contributing
 

--- a/src/ui/session_mixin.py
+++ b/src/ui/session_mixin.py
@@ -157,5 +157,5 @@ class SessionMixin:
             f"{APP_NAME} {APP_VERSION_STRING}\n\n"
             f"{APP_DESCRIPTION}\n\n"
             "Designed to replace EcuFlash for ROM editing tasks.\n"
-            "Works with RomDrop for ECU flashing.",
+            "Native ECU flashing via J2534/UDS.",
         )


### PR DESCRIPTION
## Summary
- Replaced "Works with RomDrop for ECU flashing." with "Native ECU flashing via J2534/UDS." in the About dialog
- Updated README references: setup wizard description, file tree comment, and development status line now reflect native flashing instead of RomDrop
- Internal code comments (reverse-engineering provenance) intentionally preserved

Closes #39

## Test plan
- [x] All 577 tests pass
- [ ] Verify About dialog text reads "Native ECU flashing via J2534/UDS."

https://claude.ai/code/session_01GzmV8gYK85araQQiwWU45c