### PR TITLE
Fix: compiled version opens second blank window for MCP server (#41)

### DIFF
--- a/.claude/notes.md
+++ b/.claude/notes.md
@@ -5,6 +5,9 @@
 - `examples/metadata/LFDJEA.xml` is untracked — may need committing
 - **Review romdrop.crc fallback** — `src/ecu/rom_utils.py:169` silently skips CRC verification if `romdrop.crc` is missing. Patching still proceeds without validation. Need to decide: should patching be blocked without the CRC database, or is a warning sufficient?
 
+## Recent Completed Work (Mar 30, 2026) - MCP Second Window Fix (#41)
+- **Fixed compiled version opening second blank window for MCP server** — In PyInstaller builds, `sys.executable` is the app exe, so `subprocess.Popen([sys.executable, "-m", "src.mcp.server"])` re-launched the entire GUI. Now sets `NCFLASH_MCP_MODE=1` env var when spawning subprocess; `main()` checks this and bypasses GUI to run MCP server directly. Also uses `STARTUPINFO`/`CREATE_NO_WINDOW` on Windows to suppress any window creation.
+
 ## Recent Completed Work (Mar 29, 2026) - Scan RAM UI
 - **"Scan RAM" button in ECU window** — Exposes the existing `scan_ram()` backend (reads 192 blocks of 0x1F0 bytes from ECU RAM 0x0000-0xBFFF) as a UI button alongside Read ROM and DTCs
 - **Threaded with progress** — Uses `_FlashWorker` pattern with `SCANNING_RAM` state, shows block-by-block progress, abortable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to NC Flash are documented here.
 - **Scan RAM button in ECU window** — Reads ECU RAM at 0xFFFF0000–0xFFFFBFFF (192 pages of 0x100 bytes, 48 KB) via UDS and saves the dump to `~/.nc-flash/reads/`. Uses the existing session, shows page-by-page progress, and supports abort. Based on romdrop's `uds_ScanRAM`
 
 ### Fixed
+- **Compiled version opens a second blank window for MCP server (#41)** — In PyInstaller builds, `sys.executable` points to the app exe, so spawning the MCP server via `python -m src.mcp.server` re-launched the entire GUI. Now uses an `NCFLASH_MCP_MODE` environment variable to bypass the GUI and run only the MCP server, plus suppresses window creation on Windows
 - **DTC toggle switch not showing on Windows 10 (#32)** — Window auto-sizing was based on the hidden table widget's tiny 1-cell dimensions, leaving no room for the toggle container. Now sizes from the toggle's own size hint when in toggle mode
 - **DTC toggle animates on window open** — Toggle switch now snaps to its initial position immediately instead of visually sliding into place when the window opens
 - **Tables with `%d` or `%x` format display as `0.00` after editing** — `format_value()` failed on integer/hex format specifiers because Python's `d`/`x` formats reject floats. Now converts to `int` first. Affects 176 scalings using `%d` and 3 using `%08x`

--- a/main.py
+++ b/main.py
@@ -2025,6 +2025,14 @@ class MainWindow(
 
 def main():
     """Application entry point"""
+    # If launched as MCP server subprocess (frozen/compiled builds), run
+    # the MCP server directly and exit — no GUI, no Qt.
+    if os.environ.get("NCFLASH_MCP_MODE"):
+        from src.mcp.server import main as mcp_main
+
+        mcp_main()
+        return
+
     # Initialize logging before anything else
     # Default: INFO level to console, optionally to file
     log_file = Path.home() / ".nc-flash" / "nc-flash.log"

--- a/src/ui/mcp_mixin.py
+++ b/src/ui/mcp_mixin.py
@@ -67,19 +67,32 @@ class McpMixin:
         try:
             self._start_command_server()
 
-            self._mcp_process = subprocess.Popen(
-                [
-                    sys.executable,
-                    "-m",
-                    "src.mcp.server",
-                    "--transport",
-                    "sse",
-                    "--port",
-                    str(self.MCP_SSE_PORT),
-                ],
-                cwd=str(get_app_root()),
-                stderr=subprocess.PIPE,
-            )
+            mcp_args = ["--transport", "sse", "--port", str(self.MCP_SSE_PORT)]
+            env = os.environ.copy()
+            kwargs = dict(cwd=str(get_app_root()), stderr=subprocess.PIPE)
+
+            if getattr(sys, "frozen", False):
+                # Frozen (PyInstaller) build: sys.executable is the app exe.
+                # Set NCFLASH_MCP_MODE so the exe skips the GUI and runs
+                # the MCP server directly.  Pass MCP args via sys.argv.
+                env["NCFLASH_MCP_MODE"] = "1"
+                cmd = [sys.executable] + mcp_args
+                kwargs["env"] = env
+
+                # On Windows, prevent the subprocess from creating a visible
+                # window (the exe is a GUI app with console=False).
+                if sys.platform == "win32":
+                    si = subprocess.STARTUPINFO()
+                    si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+                    si.wShowWindow = 0  # SW_HIDE
+                    kwargs["startupinfo"] = si
+                    # CREATE_NO_WINDOW prevents a console flash as well.
+                    kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
+            else:
+                # Dev mode: run as a normal Python module.
+                cmd = [sys.executable, "-m", "src.mcp.server"] + mcp_args
+
+            self._mcp_process = subprocess.Popen(cmd, **kwargs)
             logger.info(
                 f"MCP server started (PID {self._mcp_process.pid},"
                 f" SSE on http://127.0.0.1:{self.MCP_SSE_PORT}/sse)"


### PR DESCRIPTION
## Summary
- In PyInstaller builds, `sys.executable` points to the app exe (`NCFlash.exe`), so spawning the MCP server via `subprocess.Popen([sys.executable, "-m", "src.mcp.server"])` re-launched the entire GUI as a second blank window
- Now sets `NCFLASH_MCP_MODE=1` env var on the subprocess; `main()` detects this and runs only the MCP server, bypassing the GUI entirely
- On Windows, also uses `STARTUPINFO`/`CREATE_NO_WINDOW` flags to suppress any window creation

## Test plan
- [ ] Build with PyInstaller and verify MCP auto-start no longer opens a second window
- [ ] Verify manual MCP start still works correctly in compiled build
- [ ] Verify MCP server works normally in dev mode (`python main.py`)
- [ ] All 577 existing tests pass

Closes #41

https://claude.ai/code/session_013MKK17ucdp4oMx6qhboBny