### PR TITLE
fix: safety-critical bounds checking and atomic writes (#57-#61)

### DIFF
--- a/.claude/notes.md
+++ b/.claude/notes.md
@@ -1,5 +1,14 @@
 # Session Notes
 
+## Recent Completed Work (Apr 3, 2026) - Safety-Critical Bounds & Atomic Writes (#57-#61)
+- **Integer overflow validation (#59)** — Added `STORAGE_TYPE_BOUNDS` to `storage_types.py` and `_validate_and_pack()` method on `RomReader`. All 3 write methods (`write_table_data`, `write_cell_value`, `write_axis_value`) now validate integer values against storage type bounds before `struct.pack()`. Raises `RomWriteError` with value, type, and range.
+- **Interleaved 3D read bounds (#57)** — `_read_interleaved_3d()` now validates M/N are non-zero and total table footprint fits in ROM before any data access. Raises `RomReadError` with table name, M, N, address.
+- **Interleaved 3D write bounds (#58)** — `write_table_data()` interleaved branch now validates entire write footprint fits in ROM and rejects multi-byte storage types (stride too small). Raises `RomWriteError`.
+- **Cell/axis index validation (#60)** — `write_cell_value()` validates row/col against table dimensions before computing address. `write_axis_value()` validates index against axis length. Uses ROM-derived M/N for interleaved tables. Raises `RomWriteError`.
+- **Atomic project file writes (#61)** — Added `_atomic_copy()` and `_atomic_write_binary()` to `ProjectManager`. Replaced 4 non-atomic writes: create_project (v0 + working), commit_changes (snapshot), revert_to_version (working ROM overwrite). All use tmp+fsync+os.replace pattern with cleanup on failure.
+- **18 new tests** — 15 in `test_interleaved_tables.py` (read/write bounds, index validation, integer overflow), 3 in `test_project_manager.py` (atomic writes).
+- **Branch:** `fix/safety-critical-bounds-atomics-57-61` — NOT committed yet.
+
 ## Recent Completed Work (Apr 2, 2026) - DTC NRC 0x22 Fix (#52)
 - **Handle NRC 0x22 gracefully in DTC reads** — `read_dtc_count()` and `read_dtc_status()` in protocol.py now catch NRC 0x22 and return 0/[] instead of raising. Defense-in-depth added in flash_manager.py `read_dtcs()`.
 - **Isolate DTC reads from VIN/ROM ID** — In flash_setup_dialog.py and flash_mixin.py, DTC read is now wrapped in its own try/except so failures don't discard already-read VIN and ROM ID.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ All notable changes to NC Flash are documented here.
 ### Fixed
 - **DTC read failure crashes ECU info worker (#52)** — ReadDTCByStatus (SID 0x18) NRC 0x22 "Conditions not correct" now returns empty results gracefully instead of raising. DTC read failures no longer discard already-read VIN and ROM ID in the flash setup dialog and ECU info view
 - **Smoothing snaps values to coarse increments** — Smoothing used `round_one_level_coarser` which reduced precision by one decimal level (e.g. 2.03 → 2.0 for `.2f` tables). Now rounds to the format's native precision instead
+- **Interleaved 3D read has no bounds checking (#57)** — `_read_interleaved_3d()` now validates M/N are non-zero and total table footprint fits in ROM before any data access. Corrupt ROMs raise `RomReadError` with clear diagnostics instead of crashing
+- **Interleaved 3D write can overflow ROM bounds (#58)** — `write_table_data()` interleaved branch now validates entire write footprint fits in ROM and rejects multi-byte storage types incompatible with interleaved stride
+- **Integer overflow in scaling conversion (#59)** — All three write methods (`write_table_data`, `write_cell_value`, `write_axis_value`) now validate integer values against storage type bounds before `struct.pack()`. Values outside the valid range raise `RomWriteError` instead of crashing or silently wrapping
+- **Cell write index not validated (#60)** — `write_cell_value()` validates row/col against table dimensions and `write_axis_value()` validates index against axis length before computing addresses. Out-of-bounds indices raise `RomWriteError` instead of silently corrupting neighboring tables
+- **Project file writes not atomic (#61)** — ROM snapshot copies, working ROM overwrites on revert, and project creation copies now use atomic tmp+fsync+rename pattern. Crash during save no longer corrupts ROM snapshots or working files
 
 ## [v2.5.0] - 2026-04-01
 

--- a/src/core/project_manager.py
+++ b/src/core/project_manager.py
@@ -72,12 +72,12 @@ class ProjectManager:
             # v0 = pristine backup (never modified)
             v0_filename = f"v0_{rom_id}_original.bin"
             v0_path = project_dir / v0_filename
-            shutil.copy2(source_path, v0_path)
+            self._atomic_copy(source_path, v0_path)
 
             # Working ROM (editable copy, simple name)
             working_filename = f"{rom_id}.bin"
             working_path = project_dir / working_filename
-            shutil.copy2(source_path, working_path)
+            self._atomic_copy(source_path, working_path)
 
             # Calculate checksum from pristine copy
             with open(v0_path, "rb") as f:
@@ -243,7 +243,7 @@ class ProjectManager:
             project_dir = Path(self.current_project.project_path)
             working_path = project_dir / self.current_project.working_rom
             snapshot_path = project_dir / snapshot_filename
-            shutil.copy2(working_path, snapshot_path)
+            self._atomic_copy(working_path, snapshot_path)
             logger.debug(f"Created snapshot: {snapshot_filename}")
 
             # Add to history
@@ -440,10 +440,9 @@ class ProjectManager:
 
         project_dir = Path(self.current_project.project_path)
 
-        # Overwrite working file
+        # Overwrite working file (atomic: tmp + fsync + rename)
         working_path = project_dir / self.current_project.working_rom
-        with open(working_path, "wb") as f:
-            f.write(snapshot_data)
+        self._atomic_write_binary(working_path, snapshot_data)
 
         # Soft-delete all versions newer than target
         for c in self.commits:
@@ -608,6 +607,50 @@ class ProjectManager:
 
         with open(log_path, "a", encoding="utf-8") as f:
             f.write(entry)
+
+    def _atomic_copy(self, src: Path, dst: Path) -> None:
+        """Copy a file atomically: copy to tmp, verify size, fsync, rename."""
+        tmp_path = str(dst) + ".tmp"
+        try:
+            shutil.copy2(str(src), tmp_path)
+            src_size = src.stat().st_size
+            tmp_size = os.path.getsize(tmp_path)
+            if src_size != tmp_size:
+                raise ProjectSaveError(
+                    f"Size mismatch after copy: {src_size} vs {tmp_size}"
+                )
+            with open(tmp_path, "r+b") as f:
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, str(dst))
+        except ProjectSaveError:
+            raise
+        except Exception as e:
+            raise ProjectSaveError(f"Failed to copy {src} to {dst}: {e}")
+        finally:
+            try:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+            except OSError:
+                pass
+
+    def _atomic_write_binary(self, dst: Path, data: bytes) -> None:
+        """Write binary data atomically: write to tmp, fsync, rename."""
+        tmp_path = str(dst) + ".tmp"
+        try:
+            with open(tmp_path, "wb") as f:
+                f.write(data)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, str(dst))
+        except Exception as e:
+            raise ProjectSaveError(f"Failed to write {dst}: {e}")
+        finally:
+            try:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+            except OSError:
+                pass
 
     def _save_project_file(self, project: Project):
         """Save project.json (atomic write)"""

--- a/src/core/rom_reader.py
+++ b/src/core/rom_reader.py
@@ -23,7 +23,7 @@ from .rom_definition import (
     TableLayout,
     AxisType,
 )
-from .storage_types import STORAGE_TYPE_FORMAT, DEFAULT_FORMAT_CHAR
+from .storage_types import STORAGE_TYPE_FORMAT, STORAGE_TYPE_BOUNDS, DEFAULT_FORMAT_CHAR
 from .exceptions import (
     RomFileNotFoundError,
     RomReadError,
@@ -489,11 +489,33 @@ class RomReader:
         Each row is (M+1) bytes: 1 Y-axis byte followed by M data bytes.
         """
         base = table.address_int
+        if base + 1 >= len(self.rom_data):
+            raise RomReadError(
+                f"Table '{table.name}' base address {hex(base)} exceeds ROM size"
+            )
+
         m = self.rom_data[base]  # X axis count
         n = self.rom_data[base + 1]  # Y axis count (row count)
+
+        if m == 0 or n == 0:
+            raise RomReadError(
+                f"Invalid interleaved dimensions for '{table.name}': "
+                f"M={m}, N={n} at {hex(base)} (both must be > 0)"
+            )
+
         x_start = base + 2
         row_start = x_start + m
         stride = m + 1
+
+        # Validate entire table footprint fits in ROM
+        # Layout: [M][N][X_axis: M bytes][N rows of (1 Y byte + M data bytes)]
+        total_footprint = 2 + m + n * (m + 1)
+        if base + total_footprint > len(self.rom_data):
+            raise RomReadError(
+                f"Interleaved table '{table.name}' exceeds ROM bounds: "
+                f"M={m}, N={n}, footprint={total_footprint} bytes at {hex(base)}, "
+                f"ROM size={len(self.rom_data)}"
+            )
 
         # Read X axis (contiguous)
         x_axis = table.x_axis
@@ -550,6 +572,28 @@ class RomReader:
         )
         return result
 
+    def _validate_and_pack(
+        self, raw_value: float, format_string: str, format_char: str, context: str = ""
+    ) -> bytes:
+        """Validate value range for integer types and pack to bytes.
+
+        For integer format chars (B/b/H/h/I/i): round to int, check bounds, pack.
+        For float/double (f/d): pack directly without range validation.
+
+        Raises:
+            RomWriteError: If integer value is out of range for its storage type.
+        """
+        if format_char in STORAGE_TYPE_BOUNDS:
+            int_val = int(round(raw_value))
+            lo, hi = STORAGE_TYPE_BOUNDS[format_char]
+            if int_val < lo or int_val > hi:
+                raise RomWriteError(
+                    f"Value {int_val} out of range for type '{format_char}' "
+                    f"(valid: {lo}..{hi}){': ' + context if context else ''}"
+                )
+            return struct.pack(format_string, int_val)
+        return struct.pack(format_string, raw_value)
+
     def write_table_data(self, table: Table, values: np.ndarray) -> None:
         """
         Write modified table data back to ROM (in memory, not to file yet)
@@ -604,15 +648,42 @@ class RomReader:
             )
             format_string = f"{endian_char}{format_char}"
 
+            # Validate stride is sufficient for element size
+            if bytes_per_elem > 1 and m * bytes_per_elem + 1 > stride:
+                raise RomWriteError(
+                    f"Interleaved table '{table.name}': stride ({stride}) too small "
+                    f"for {m} elements of {bytes_per_elem} bytes each "
+                    f"(need {m * bytes_per_elem + 1})"
+                )
+
+            # Validate entire write footprint fits in ROM
+            if n > 0 and m > 0:
+                last_byte = (
+                    row_start
+                    + (n - 1) * stride
+                    + 1
+                    + (m - 1) * bytes_per_elem
+                    + bytes_per_elem
+                )
+                if last_byte > len(self.rom_data):
+                    raise RomWriteError(
+                        f"Interleaved write for '{table.name}' exceeds ROM bounds: "
+                        f"last byte at {hex(last_byte - 1)}, "
+                        f"ROM size={len(self.rom_data)}"
+                    )
+
             try:
                 for r in range(n):
                     for c in range(m):
                         idx = r * m + c
                         addr = row_start + r * stride + 1 + c * bytes_per_elem
                         val = raw_values[idx]
-                        if format_char in ("B", "b", "H", "h", "I", "i"):
-                            val = int(round(val))
-                        packed = struct.pack(format_string, val)
+                        packed = self._validate_and_pack(
+                            val,
+                            format_string,
+                            format_char,
+                            context=f"table '{table.name}' cell [{r},{c}]",
+                        )
                         self.rom_data[addr : addr + len(packed)] = packed
                 logger.info(f"Successfully wrote interleaved table data: {table.name}")
             except Exception as e:
@@ -687,21 +758,40 @@ class RomReader:
             # Interleaved: [M][N][X_axis][Y0 D0..DM-1][Y1 D0..DM-1]...
             base = table.address_int
             m = self.rom_data[base]
+            n = self.rom_data[base + 1]
+            max_cols, max_rows = m, n
+        elif table.type.value == "3D":
+            x_axis = table.x_axis
+            y_axis = table.y_axis
+            max_cols = x_axis.elements if x_axis else 1
+            max_rows = y_axis.elements if y_axis else 1
+        else:
+            max_rows = table.elements
+            max_cols = 1
+
+        # Validate row/col indices against table dimensions
+        if row < 0 or row >= max_rows:
+            raise RomWriteError(
+                f"Row index {row} out of range for table '{table.name}' "
+                f"(valid: 0..{max_rows - 1})"
+            )
+        if col < 0 or col >= max_cols:
+            raise RomWriteError(
+                f"Column index {col} out of range for table '{table.name}' "
+                f"(valid: 0..{max_cols - 1})"
+            )
+
+        # Compute address using validated indices
+        if table.layout == TableLayout.INTERLEAVED and table.type.value == "3D":
             row_start = base + 2 + m
             stride = m + 1
             address = row_start + row * stride + 1 + col * bytes_per_elem
         elif table.type.value == "3D":
-            # Contiguous 3D: calculate linear index from row, col
-            x_axis = table.x_axis
-            y_axis = table.y_axis
-            cols = x_axis.elements if x_axis else 1
-            rows = y_axis.elements if y_axis else 1
-
             # Must match the reshape order used in read_table_data
             if table.swapxy:
-                linear_index = col * rows + row
+                linear_index = col * max_rows + row
             else:
-                linear_index = row * cols + col
+                linear_index = row * max_cols + col
             address = table.address_int + (linear_index * bytes_per_elem)
         else:
             # For 1D/2D tables, just use row
@@ -715,11 +805,12 @@ class RomReader:
         format_string = f"{endian_char}{format_char}"
 
         try:
-            # Convert to appropriate integer type if needed
-            if format_char in ("B", "b", "H", "h", "I", "i"):
-                raw_value = int(round(raw_value))
-
-            packed_data = struct.pack(format_string, raw_value)
+            packed_data = self._validate_and_pack(
+                raw_value,
+                format_string,
+                format_char,
+                context=f"table '{table.name}' cell [{row},{col}]",
+            )
 
             # Validate bounds
             if address < 0 or address >= len(self.rom_data):
@@ -770,12 +861,25 @@ class RomReader:
                 f"Scaling '{axis_table.scaling}' not found for axis in table '{table.name}'"
             )
 
-        # Calculate the byte offset
+        # Validate index against axis length
         bytes_per_elem = scaling.bytes_per_element
-        if table.layout == TableLayout.INTERLEAVED and axis_type == "y_axis":
-            # Y axis values are interleaved: first byte of each row
+        if table.layout == TableLayout.INTERLEAVED:
             base = table.address_int
             m = self.rom_data[base]
+            n = self.rom_data[base + 1]
+            max_index = n if axis_type == "y_axis" else m
+        else:
+            max_index = axis_table.elements
+
+        if index < 0 or index >= max_index:
+            raise RomWriteError(
+                f"Axis index {index} out of range for {axis_type} of "
+                f"table '{table.name}' (valid: 0..{max_index - 1})"
+            )
+
+        # Calculate the byte offset
+        if table.layout == TableLayout.INTERLEAVED and axis_type == "y_axis":
+            # Y axis values are interleaved: first byte of each row
             row_start = base + 2 + m
             stride = m + 1
             address = row_start + index * stride
@@ -789,11 +893,12 @@ class RomReader:
         format_string = f"{endian_char}{format_char}"
 
         try:
-            # Convert to appropriate integer type if needed
-            if format_char in ("B", "b", "H", "h", "I", "i"):
-                raw_value = int(round(raw_value))
-
-            packed_data = struct.pack(format_string, raw_value)
+            packed_data = self._validate_and_pack(
+                raw_value,
+                format_string,
+                format_char,
+                context=f"table '{table.name}' {axis_type}[{index}]",
+            )
 
             # Validate bounds
             if address < 0 or address >= len(self.rom_data):

--- a/src/core/storage_types.py
+++ b/src/core/storage_types.py
@@ -31,6 +31,17 @@ STORAGE_TYPE_BYTES = {
     "double": 8,
 }
 
+# Integer format char → (min_value, max_value) for pre-pack validation
+# Float/double types intentionally omitted (IEEE 754 handles overflow via inf/nan)
+STORAGE_TYPE_BOUNDS = {
+    "B": (0, 255),
+    "b": (-128, 127),
+    "H": (0, 65535),
+    "h": (-32768, 32767),
+    "I": (0, 4294967295),
+    "i": (-2147483648, 2147483647),
+}
+
 # Default values used when storage type is unknown
 DEFAULT_FORMAT_CHAR = "f"
 DEFAULT_BYTE_SIZE = 4

--- a/tests/test_interleaved_tables.py
+++ b/tests/test_interleaved_tables.py
@@ -19,6 +19,7 @@ from src.core.rom_definition import (
     TableLayout,
 )
 from src.core.rom_reader import RomReader, ScalingConverter
+from src.core.exceptions import RomReadError, RomWriteError
 
 
 def make_romid():
@@ -289,3 +290,213 @@ class TestContiguousUnchanged:
         """Check enum string values match XML attribute values."""
         assert TableLayout.CONTIGUOUS.value == "contiguous"
         assert TableLayout.INTERLEAVED.value == "interleaved"
+
+
+# --- Helper to create a reader from a ROM + table ---
+def _make_reader(rom, m, n, scaling_name="u8", storagetype="uint8"):
+    scaling = make_scaling(name=scaling_name, storagetype=storagetype)
+    definition = RomDefinition(
+        romid=make_romid(),
+        scalings={scaling_name: scaling},
+        tables=[make_interleaved_table("test", "100", m, n, scaling_name=scaling_name)],
+    )
+    reader = RomReader.__new__(RomReader)
+    reader.rom_data = rom
+    reader.definition = definition
+    reader.rom_path = "test.bin"
+    return reader, definition.tables[0]
+
+
+class TestInterleavedReadValidation:
+    """Test bounds checking when reading interleaved 3D tables (#57)."""
+
+    def test_read_m_zero_raises(self):
+        """M=0 should raise RomReadError."""
+        rom = bytearray(512)
+        rom[0x100] = 0  # M = 0
+        rom[0x101] = 3  # N = 3
+        reader, table = _make_reader(rom, 0, 3)
+        # Fix elements to match M*N=0
+        table._elements_override = 0
+        with pytest.raises(RomReadError, match="M=0"):
+            reader.read_table_data(table)
+
+    def test_read_n_zero_raises(self):
+        """N=0 should raise RomReadError."""
+        rom = bytearray(512)
+        rom[0x100] = 3  # M = 3
+        rom[0x101] = 0  # N = 0
+        reader, table = _make_reader(rom, 3, 0)
+        with pytest.raises(RomReadError, match="N=0"):
+            reader.read_table_data(table)
+
+    def test_read_exceeds_rom_raises(self):
+        """M=255 on a small ROM should raise RomReadError."""
+        # ROM only 300 bytes, but M=255, N=3 needs 2+255+3*256 = 1025 bytes from base
+        rom = bytearray(300)
+        rom[0x100] = 255  # M = 255
+        rom[0x101] = 3  # N = 3
+        reader, table = _make_reader(rom, 255, 3)
+        with pytest.raises(RomReadError, match="exceeds ROM bounds"):
+            reader.read_table_data(table)
+
+    def test_read_valid_3x3_no_error(self):
+        """A well-formed 3x3 table should read without error (regression guard)."""
+        rom = build_interleaved_rom(
+            3, 3, [10, 20, 30], [40, 80, 120], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        )
+        reader, table = _make_reader(rom, 3, 3)
+        result = reader.read_table_data(table)
+        assert result["values"].shape == (3, 3)
+
+
+class TestInterleavedWriteValidation:
+    """Test bounds checking when writing interleaved 3D tables (#58)."""
+
+    def test_write_table_data_exceeds_rom(self):
+        """Write to a ROM that's 1 byte too short should raise RomWriteError."""
+        m, n = 3, 3
+        # Build a correct ROM then truncate by 1 byte
+        rom = build_interleaved_rom(
+            m, n, [10, 20, 30], [40, 80, 120], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        )
+        rom = bytearray(rom[:-65])  # Remove the 64-byte padding + 1 more
+        reader, table = _make_reader(rom, m, n)
+        new_values = np.array([[10, 20, 30], [40, 50, 60], [70, 80, 90]], dtype=float)
+        with pytest.raises(RomWriteError, match="exceeds ROM bounds"):
+            reader.write_table_data(table, new_values)
+
+    def test_write_multibyte_interleaved_raises(self):
+        """uint16 interleaved should raise because stride is too small."""
+        m, n = 3, 3
+        rom = build_interleaved_rom(
+            m, n, [10, 20, 30], [40, 80, 120], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        )
+        reader, table = _make_reader(
+            rom, m, n, scaling_name="u16", storagetype="uint16"
+        )
+        new_values = np.array([[10, 20, 30], [40, 50, 60], [70, 80, 90]], dtype=float)
+        with pytest.raises(RomWriteError, match="stride"):
+            reader.write_table_data(table, new_values)
+
+    def test_write_normal_interleaved_succeeds(self):
+        """Standard uint8 interleaved write should still work (regression)."""
+        m, n = 3, 3
+        rom = build_interleaved_rom(
+            m, n, [10, 20, 30], [40, 80, 120], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        )
+        reader, table = _make_reader(rom, m, n)
+        new_values = np.array([[10, 20, 30], [40, 50, 60], [70, 80, 90]], dtype=float)
+        reader.write_table_data(table, new_values)
+        result = reader.read_table_data(table)
+        np.testing.assert_array_equal(result["values"], new_values)
+
+
+class TestCellIndexValidation:
+    """Test cell and axis index validation (#60)."""
+
+    def test_write_cell_row_too_large(self):
+        """Row beyond table dimensions should raise."""
+        rom = build_interleaved_rom(
+            3, 3, [10, 20, 30], [40, 80, 120], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        )
+        reader, table = _make_reader(rom, 3, 3)
+        with pytest.raises(RomWriteError, match="Row index 5 out of range"):
+            reader.write_cell_value(table, row=5, col=0, raw_value=1)
+
+    def test_write_cell_col_too_large(self):
+        """Column beyond table dimensions should raise."""
+        rom = build_interleaved_rom(
+            3, 3, [10, 20, 30], [40, 80, 120], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        )
+        reader, table = _make_reader(rom, 3, 3)
+        with pytest.raises(RomWriteError, match="Column index 5 out of range"):
+            reader.write_cell_value(table, row=0, col=5, raw_value=1)
+
+    def test_write_cell_negative_row(self):
+        """Negative row should raise."""
+        rom = build_interleaved_rom(
+            3, 3, [10, 20, 30], [40, 80, 120], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        )
+        reader, table = _make_reader(rom, 3, 3)
+        with pytest.raises(RomWriteError, match="Row index -1 out of range"):
+            reader.write_cell_value(table, row=-1, col=0, raw_value=1)
+
+    def test_write_cell_valid_indices(self):
+        """Valid indices should work (regression)."""
+        rom = build_interleaved_rom(
+            3, 3, [10, 20, 30], [40, 80, 120], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        )
+        reader, table = _make_reader(rom, 3, 3)
+        reader.write_cell_value(table, row=2, col=2, raw_value=99)
+        result = reader.read_table_data(table)
+        assert result["values"][2, 2] == 99
+
+    def test_write_axis_index_too_large(self):
+        """Axis index beyond length should raise."""
+        rom = build_interleaved_rom(
+            3, 3, [10, 20, 30], [40, 80, 120], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        )
+        reader, table = _make_reader(rom, 3, 3)
+        with pytest.raises(RomWriteError, match="Axis index 5 out of range"):
+            reader.write_axis_value(table, "y_axis", 5, raw_value=1)
+
+    def test_write_axis_negative_index(self):
+        """Negative axis index should raise."""
+        rom = build_interleaved_rom(
+            3, 3, [10, 20, 30], [40, 80, 120], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        )
+        reader, table = _make_reader(rom, 3, 3)
+        with pytest.raises(RomWriteError, match="Axis index -1 out of range"):
+            reader.write_axis_value(table, "x_axis", -1, raw_value=1)
+
+
+class TestIntegerOverflowValidation:
+    """Test integer overflow validation in struct.pack (#59)."""
+
+    def test_write_cell_uint8_overflow(self):
+        """Value 256 in uint8 cell should raise RomWriteError."""
+        rom = build_interleaved_rom(
+            3, 3, [10, 20, 30], [40, 80, 120], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        )
+        reader, table = _make_reader(rom, 3, 3)
+        with pytest.raises(RomWriteError, match="out of range"):
+            reader.write_cell_value(table, row=0, col=0, raw_value=256)
+
+    def test_write_cell_int8_underflow(self):
+        """Value -129 in int8 cell should raise RomWriteError."""
+        rom = build_interleaved_rom(
+            3, 3, [10, 20, 30], [40, 80, 120], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        )
+        reader, table = _make_reader(rom, 3, 3, scaling_name="i8", storagetype="int8")
+        with pytest.raises(RomWriteError, match="out of range"):
+            reader.write_cell_value(table, row=0, col=0, raw_value=-129)
+
+    def test_write_cell_valid_uint8(self):
+        """Value 200 in uint8 should succeed."""
+        rom = build_interleaved_rom(
+            3, 3, [10, 20, 30], [40, 80, 120], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        )
+        reader, table = _make_reader(rom, 3, 3)
+        reader.write_cell_value(table, row=0, col=0, raw_value=200)
+        result = reader.read_table_data(table)
+        assert result["values"][0, 0] == 200
+
+    def test_write_axis_uint8_overflow(self):
+        """Value 300 in uint8 axis should raise RomWriteError."""
+        rom = build_interleaved_rom(
+            3, 3, [10, 20, 30], [40, 80, 120], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        )
+        reader, table = _make_reader(rom, 3, 3)
+        with pytest.raises(RomWriteError, match="out of range"):
+            reader.write_axis_value(table, "x_axis", 0, raw_value=300)
+
+    def test_write_table_data_uint8_overflow(self):
+        """Bulk write with one value out of range should raise RomWriteError."""
+        rom = build_interleaved_rom(
+            3, 3, [10, 20, 30], [40, 80, 120], [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        )
+        reader, table = _make_reader(rom, 3, 3)
+        bad_values = np.array([[1, 2, 3], [4, 500, 6], [7, 8, 9]], dtype=float)
+        with pytest.raises(RomWriteError, match="out of range"):
+            reader.write_table_data(table, bad_values)

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -15,7 +15,7 @@ from src.core.version_models import (
     TableChanges,
     CellChange,
 )
-from src.core.exceptions import ProjectError
+from src.core.exceptions import ProjectError, ProjectSaveError
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -499,3 +499,51 @@ class TestCommitDialogSanitization:
         from src.ui.commit_dialog import CommitDialog
 
         assert CommitDialog._sanitize_name("v2 timing") == "v2_timing"
+
+
+# ===========================================================================
+# Atomic writes (#61)
+# ===========================================================================
+
+
+class TestAtomicWrites:
+    def test_snapshot_size_matches_source(self, pm, project_dir):
+        """Snapshot file should have same size as working ROM after commit."""
+        changes = _make_changes()
+        commit = pm.commit_changes(message="test", changes=changes, version_name="a")
+        snapshot_path = project_dir / commit.snapshot_filename
+        working_path = project_dir / pm.current_project.working_rom
+        assert snapshot_path.stat().st_size == working_path.stat().st_size
+
+    def test_revert_restores_snapshot_content(self, pm, project_dir):
+        """After revert, working ROM should match the target snapshot."""
+        changes = _make_changes()
+        commit_v1 = pm.commit_changes(message="v1", changes=changes, version_name="a")
+        # Modify the working ROM
+        working_path = project_dir / pm.current_project.working_rom
+        working_path.write_bytes(b"\xFF" * 1024)
+        # Commit v2 with modified data
+        commit_v2 = pm.commit_changes(message="v2", changes=changes, version_name="b")
+        # Read v1 snapshot content
+        v1_snapshot = (project_dir / commit_v1.snapshot_filename).read_bytes()
+        # Revert to v1
+        pm.revert_to_version(commit_v1.version)
+        # Working ROM should now match v1 snapshot
+        assert working_path.read_bytes() == v1_snapshot
+
+    def test_atomic_copy_cleans_up_on_failure(self, pm, project_dir, monkeypatch):
+        """If os.replace fails, .tmp file should be cleaned up."""
+        import os
+
+        original_replace = os.replace
+
+        def fail_replace(src, dst):
+            raise OSError("simulated replace failure")
+
+        monkeypatch.setattr(os, "replace", fail_replace)
+        source = project_dir / pm.current_project.working_rom
+        dest = project_dir / "test_copy.bin"
+        with pytest.raises(ProjectSaveError):
+            pm._atomic_copy(source, dest)
+        # No .tmp file should remain
+        assert not (project_dir / "test_copy.bin.tmp").exists()


### PR DESCRIPTION
## Summary
- **#57** — Interleaved 3D read: validate M/N non-zero and total footprint fits in ROM before data access
- **#58** — Interleaved 3D write: pre-validate entire write footprint and reject multi-byte stride overflow
- **#59** — Integer overflow: new `_validate_and_pack()` helper checks integer bounds before `struct.pack()`
- **#60** — Cell/axis index: validate row/col against table dimensions before computing addresses
- **#61** — Atomic writes: `_atomic_copy()` and `_atomic_write_binary()` for snapshot, revert, and project creation

Closes #57, closes #58, closes #59, closes #60, closes #61

## Test plan
- [x] 18 new tests covering all validation paths (read bounds, write bounds, index validation, integer overflow, atomic writes)
- [x] Full test suite: 716 passed, 0 failures
- [x] Verified interleaved tables load correctly with real TCM ROM definition (lfg1tf000.xml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)