### PR TITLE
feat: add screenshot buttons to main window and table viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to NC Flash are documented here.
 ## [Unreleased]
 
 ### Added
+- **Screenshot buttons (F12)** — Camera toolbar button and menu entry in both the main window (Tools > Screenshot) and table viewer window (File > Screenshot). Captures the window as PNG via save dialog with auto-generated filename
 - **J2534 device layer tests (#54)** — 53 tests covering message construction, all 26 error codes, ISO-TP filter setup, read/write, open/close, and connect/disconnect
 - **Security stub tests (#55)** — 5 always-run CI tests verifying stub raises `SecureModuleNotAvailable` and flash operations are blocked when the private module is absent
 - **Flash abort scenario tests (#56)** — 14 tests covering abort during SBL upload, ROM transfer, pre-transfer phase, connection drops, and cleanup failures

--- a/main.py
+++ b/main.py
@@ -458,6 +458,12 @@ class MainWindow(
         ecu_prog_action.setShortcut("Ctrl+Shift+E")
         ecu_prog_action.triggered.connect(self._on_open_ecu_window)
 
+        tools_menu.addSeparator()
+
+        screenshot_action = tools_menu.addAction("&Screenshot")
+        screenshot_action.setShortcut("F12")
+        screenshot_action.triggered.connect(self._take_screenshot)
+
         # Help menu (Alt+H)
         help_menu = menubar.addMenu("&Help")
 
@@ -471,7 +477,8 @@ class MainWindow(
         tb.setMovable(False)
         tb.setFloatable(False)
         tb.setIconSize(QSize(20, 20))
-        tb.setStyleSheet("""
+        tb.setStyleSheet(
+            """
             QToolBar {
                 spacing: 1px;
                 padding: 1px 4px;
@@ -489,7 +496,8 @@ class MainWindow(
             QToolButton:pressed {
                 background: rgba(128, 128, 128, 0.3);
             }
-        """)
+        """
+        )
 
         act = tb.addAction(self._make_icon("open"), "")
         act.setToolTip("Open  (Ctrl+O)")
@@ -526,6 +534,39 @@ class MainWindow(
         act = tb.addAction(self._make_icon("settings"), "")
         act.setToolTip("Settings")
         act.triggered.connect(self.show_settings)
+
+        tb.addSeparator()
+
+        act = tb.addAction(self._make_icon("screenshot"), "")
+        act.setToolTip("Screenshot  (F12)")
+        act.triggered.connect(self._take_screenshot)
+
+    def _take_screenshot(self):
+        """Capture a screenshot of the main window and save to user-chosen location."""
+        document = self.get_current_document()
+        if document and document.file_name:
+            stem = Path(document.file_name).stem
+        else:
+            stem = "nc-flash"
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        default_name = f"{stem}_{timestamp}.png"
+
+        file_path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Save Screenshot",
+            default_name,
+            "PNG Images (*.png);;All Files (*)",
+        )
+        if not file_path:
+            return
+
+        pixmap = self.grab()
+        if pixmap.save(file_path):
+            self.statusBar().showMessage(f"Screenshot saved: {file_path}")
+        else:
+            QMessageBox.critical(
+                self, "Error", f"Failed to save screenshot to:\n{file_path}"
+            )
 
     def _make_icon(self, name: str) -> QIcon:
         """Create a crisp toolbar icon by name using QPainter."""

--- a/src/ui/icons.py
+++ b/src/ui/icons.py
@@ -263,6 +263,21 @@ def _draw_round(p, c):
     p.drawEllipse(QPointF(17, 4), 1.5, 1.5)
 
 
+def _draw_screenshot(p, c):
+    """Camera icon for screenshot action."""
+    pen = QPen(c, 1.6, Qt.SolidLine, Qt.RoundCap, Qt.RoundJoin)
+    p.setPen(pen)
+    p.setBrush(Qt.NoBrush)
+    # Camera body
+    p.drawRoundedRect(2, 7, 16, 11, 2, 2)
+    # Viewfinder bump on top
+    p.drawLine(7, 7, 7, 5)
+    p.drawLine(7, 5, 13, 5)
+    p.drawLine(13, 5, 13, 7)
+    # Lens circle
+    p.drawEllipse(QPointF(10, 12.5), 3.5, 3.5)
+
+
 # Dispatch table
 _ICON_DRAWERS = {
     # Main window
@@ -288,4 +303,6 @@ _ICON_DRAWERS = {
     "smooth": _draw_smooth,
     "round": _draw_round,
     "graph": _draw_graph,
+    # Shared
+    "screenshot": _draw_screenshot,
 }

--- a/src/ui/table_viewer_window.py
+++ b/src/ui/table_viewer_window.py
@@ -15,6 +15,7 @@ from PySide6.QtWidgets import (
     QHBoxLayout,
     QWidget,
     QApplication,
+    QFileDialog,
     QSplitter,
     QMessageBox,
     QToolBar,
@@ -250,6 +251,10 @@ class TableViewerWindow(QMainWindow):
         export_csv_action.setShortcut("Ctrl+E")
         export_csv_action.triggered.connect(self._export_to_csv)
 
+        screenshot_action = file_menu.addAction("Screenshot")
+        screenshot_action.setShortcut("F12")
+        screenshot_action.triggered.connect(self._take_screenshot)
+
         # Edit menu (Alt+E)
         edit_menu = menubar.addMenu("&Edit")
 
@@ -343,7 +348,8 @@ class TableViewerWindow(QMainWindow):
         tb.setMovable(False)
         tb.setFloatable(False)
         tb.setIconSize(QSize(20, 20))
-        tb.setStyleSheet("""
+        tb.setStyleSheet(
+            """
             QToolBar {
                 spacing: 1px;
                 padding: 1px 4px;
@@ -365,7 +371,8 @@ class TableViewerWindow(QMainWindow):
                 background: rgba(0, 120, 215, 0.15);
                 border: 1px solid rgba(0, 120, 215, 0.4);
             }
-        """)
+        """
+        )
         self._toolbar = tb
 
         # --- File actions ---
@@ -451,6 +458,12 @@ class TableViewerWindow(QMainWindow):
         else:
             self._tb_graph_action = None
 
+        tb.addSeparator()
+
+        act = tb.addAction(self._make_toolbar_icon("screenshot"), "")
+        act.setToolTip("Screenshot  (F12)")
+        act.triggered.connect(self._take_screenshot)
+
     def _make_toolbar_icon(self, name: str):
         """Create a crisp toolbar icon by name using QPainter."""
         from .icons import make_icon
@@ -496,6 +509,30 @@ class TableViewerWindow(QMainWindow):
     def _export_to_csv(self):
         """Export table to CSV and open with default application"""
         self.viewer.export_to_csv(self.rom_path)
+
+    def _take_screenshot(self):
+        """Capture a screenshot of this table viewer window and save to user-chosen location."""
+        from datetime import datetime
+
+        table_name = self.table.name.replace(" ", "_").replace("/", "-")
+        rom_stem = Path(self.rom_path).stem if self.rom_path else "table"
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        default_name = f"{rom_stem}_{table_name}_{timestamp}.png"
+
+        file_path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Save Screenshot",
+            default_name,
+            "PNG Images (*.png);;All Files (*)",
+        )
+        if not file_path:
+            return
+
+        pixmap = self.grab()
+        if not pixmap.save(file_path):
+            QMessageBox.critical(
+                self, "Error", f"Failed to save screenshot to:\n{file_path}"
+            )
 
     def _toggle_graph(self):
         """Toggle graph panel visibility"""


### PR DESCRIPTION
## Summary
- Adds a camera icon toolbar button (F12) to the **main window** (Tools > Screenshot) and **table viewer** (File > Screenshot)
- Captures the window as PNG via a save-file dialog with auto-generated filename (ROM name + table name + timestamp)
- New shared camera icon in `src/ui/icons.py`

## Test plan
- [ ] Open a ROM, press F12 in main window — save dialog appears, PNG saved correctly
- [ ] Open a table, press F12 in table viewer — save dialog with table-specific filename
- [ ] Cancel the dialog — nothing happens, no errors
- [ ] Verify toolbar camera icons render properly in both windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)