### PR TITLE
docs: TCM read-only support + ECU-only checksum guard-note

### DIFF
--- a/.claude/notes.md
+++ b/.claude/notes.md
@@ -6,6 +6,13 @@
 - **No parser change needed** — V2 TCM defs use the SAME RomDrop XML schema as the ECU defs, so `DefinitionParser`/`RomDetector` handle them unchanged. Detection matches via `internalidstring` `SW-LFG1TF000.HEX` at `internalidaddress` 0x10612.
 - **Validation status** — Only LFG1TF000 is hardware-validated (against `examples/LFG1TF000.bin`); LFG1TG000, LFACTA000, and LFAMTA000 await real TCM dumps before they can be trusted.
 - **Scope: Phase A only** — This is data + test + docs (zero `src/` changes), closing #70. Phase B (TCM flashing) is a separate future R&D effort, NOT in this branch. See `.claude/plans/tcm-v2-import.md`.
+- **Phase A merged** — PR #73 merged to master (admin-merge after CI green; master requires review + CI, see memory `project_master_branch_protection`). Phase B filed as #72.
+
+## Recent Completed Work (Jun 14, 2026) - TCM README + checksum investigation (follow-up)
+
+- **Checksum investigation (re: TCM brick risk)** — `correct_rom_checksums()` (`src/ecu/checksum.py`) is ECU-only (table @ 0xFF650) and called from ONE place: `flash_manager._flash_rom_inner` (ECU dynamic flash), on a copy. It NEVER runs on save and NEVER on a TCM ROM. So editing+saving a TCM today is non-destructive; there's no TCM checksum handling and none is needed until Phase B. Added an ECU-only docstring guard-note to `correct_rom_checksums()` so it isn't reused for TCM. Phase B must implement its own TCM checksum routine.
+- **NC_TCM has no flash source** — public NC_TCM `tools/` ships only `NC_TCM_Read.exe` + `.gitkeep`. David's TCU flashing is an external/private tool; need him to share seed/key + flash sequence for Phase B.
+- **README** — documented TCM read support (read-only) and the V2 defs + example dump in Features and project structure.
 
 ## Recent Completed Work (Jun 10, 2026) - Auto-Blip table definitions for LF9VEB
 

--- a/.claude/plans/tcm-v2-import.md
+++ b/.claude/plans/tcm-v2-import.md
@@ -41,6 +41,12 @@
 - **Erase / program command sequences** — The exact UDS (or kernel-level) command sequence to erase flash blocks and program new data on the TCM is unknown and must be derived empirically/from RE.
 - **Checksum module** — The TCM ROM's checksum scheme (algorithm, covered ranges, table location) is unknown. It differs from the Mazda ECU checksum table at 0xFF650 and must be worked out independently before any written image will be accepted/run.
 
+**Investigation findings (Jun 14, 2026):**
+
+- **No TCM checksum is computed or corrected anywhere today.** `correct_rom_checksums()` (`src/ecu/checksum.py`) is the only checksum-correction routine, and it is **ECU-only** — hardcoded to the ECU checksum table at `0xFF650` with the Mazda 32-bit-sum scheme. It is called from exactly one place, `flash_manager._flash_rom_inner` (ECU dynamic flash), and always on a *copy*. It never runs on file save and never on a TCM ROM. So **editing + saving a TCM today is non-destructive** (no ECU logic touches it) but yields an image with stale TCM checksums — harmless because there is no TCM flash path. A docstring guard-note was added to `correct_rom_checksums()` so no future dev reuses it for the TCM.
+- **Phase B requirement:** the TCM flash path must implement and use its **own** checksum routine and must never call `correct_rom_checksums()`. The TCM def's `<checksummodule>` is currently empty and unused.
+- **NC_TCM public repo has no flash/seed-key source.** Its `tools/` folder ships only `NC_TCM_Read.exe` (read-only) and a `.gitkeep`. David's ability to flash TCUs comes from a separate/private tool — we must obtain the TCM seed/key + flash sequence from him to build Phase B.
+
 **Hard guardrails for Phase B:**
 
 - **Must NOT touch the validated ECU flash path.** The ECU read/flash code (security algorithm, flash manager, J2534 bridge) is hardware-proven and live. TCM flashing must be built as a fully separate path with no shared mutable state and no edits to ECU flashing logic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to NC Flash are documented here.
 - **V2 TCM ROM definitions** — Imported transmission control module (TCM) definitions from the NC_TCM project (djobes) for `LFG1TF000`, `LFG1TG000`, `LFACTA000`, and `LFAMTA000` (Mazda MX-5 NC transmission control module). Note: `LFG1TG000`, `LFACTA000`, and `LFAMTA000` are imported but NOT yet validated against real TCM dumps — only `LFG1TF000` has a hardware-backed test.
 - **TCM sample dump and detection test** — Added `examples/LFG1TF000.bin` sample TCM dump and `tests/test_tcm_v2_detection.py` validating real detection of the `LFG1TF000` V2 definition.
 
+### Changed
+- **TCM read-only documentation & checksum guard-note** — README now documents TCM ROM read support (read/inspect only — no TCM flashing) plus the V2 defs and example dump. Added an ECU-only guard-note to `correct_rom_checksums()` clarifying it must never run on a TCM ROM (the TCM needs its own, not-yet-implemented checksum routine — see #72). No behavior change; `correct_rom_checksums()` was already ECU-flash-only and never touches TCM ROMs.
+
 ### Removed
 - **Legacy V1 TCM definition** — Removed `examples/metadata/lfg1tf000.xml` (superseded by `LFG1TF000_v02.xml`), resolving ambiguous detection.
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ python main.py
 ### Core Features
 - Automatic ROM ID detection and XML definition matching
 - Read NC Miata ECU ROM binary files
+- Read NC Miata TCM (transmission) ROMs via the V2 TCM definitions — read/inspect only; TCM flashing is not supported
 - View 1D, 2D, and 3D tables with proper axis labels
 - Interleaved 3D table support for TCM-style ROMs
 - Save modified ROM files
@@ -268,8 +269,10 @@ nc-flash/
 ├── tests/                             # Unit and integration tests
 ├── examples/                          # Example ROM files
 │   ├── metadata/                      # ROM metadata XML files
-│   │   └── lf9veb.xml                 # NC Miata ROM definition (511 tables)
-│   └── lf9veb.bin                     # Stock NC Miata ROM binary
+│   │   ├── lf9veb.xml                 # NC Miata ECU ROM definition (511 tables)
+│   │   └── *_v02.xml                  # V2 TCM definitions (LFG1TF000/TG000, LFACTA000, LFAMTA000)
+│   ├── lf9veb.bin                     # Stock NC Miata ECU ROM binary
+│   └── LFG1TF000.bin                  # Example NC TCM ROM dump
 ├── packaging/                         # Build & installer scripts
 │   ├── build.bat                      # Windows build script
 │   ├── installer.iss                  # Inno Setup installer script

--- a/src/ecu/checksum.py
+++ b/src/ecu/checksum.py
@@ -46,6 +46,13 @@ def correct_rom_checksums(rom_data: bytearray) -> list[tuple[int, int, int, int,
 
     Verified against romdrop.exe disassembly at 0x004014B7.
 
+    ECU-ONLY: the checksum table offset (CHECKSUM_TABLE_OFFSET = 0xFF650) and
+    the Mazda 32-bit-sum scheme are specific to the NC ECU. Do NOT call this on
+    a TCM ROM — the TCM uses a different (currently un-reverse-engineered)
+    checksum scheme, and running this against a TCM image would read garbage at
+    0xFF650 and write incorrect values. TCM flashing (see issue #72) must
+    implement and use its own checksum routine before any write.
+
     Returns list of (start, end_inclusive, checksum_offset, old_value, new_value) tuples.
     """
     corrections = []


### PR DESCRIPTION
## Summary
Documentation + safety-note follow-up to the V2 TCM import (#73). **No behavior change.**

- **README** — documents TCM ROM read support (read/inspect only — no TCM flashing) in Features, and adds the V2 defs + `examples/LFG1TF000.bin` to the project-structure tree.
- **Checksum guard-note** — adds an ECU-only docstring note to `correct_rom_checksums()` so it isn't reused for TCM ROMs.
- **Phase B plan** (`.claude/plans/tcm-v2-import.md`) — records the checksum investigation and that NC_TCM ships no public flash/seed-key source.

## Checksum investigation (why no code logic changed)
`correct_rom_checksums()` is **ECU-only** (table hardcoded at `0xFF650`) and is called from exactly one place — `flash_manager._flash_rom_inner` (ECU dynamic flash) — always on a *copy*. It **never** runs on file save and **never** on a TCM ROM. So editing/saving a TCM today is non-destructive, and no TCM checksum handling is needed until TCM flashing (#72) exists, at which point it must use its own checksum routine.

## Validation
- Full suite: **853 passed, 26 skipped**; black clean.

Refs #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
