### PR TITLE
Download Logs: byte-accurate progress dialog + Cancel, utility/ECU mutual exclusion (#88)

### DIFF
--- a/.claude/notes.md
+++ b/.claude/notes.md
@@ -1,5 +1,29 @@
 # Session Notes
 
+## 🟢 feature/download-logs-progress — Download Logs UX, NC-Flash-only (Jul 13, 2026)
+
+Clean branch off master (v2.11.0) carrying ONLY the Download-Logs improvements,
+split out of the parked `feature/live-datalog-stream` branch (which stays parked
+pending the firmware-stability investigation — see that branch + its goal doc).
+No firmware changes — rides the already-released `/csv_list`, `/download_csv`,
+`/datalog` endpoints.
+
+- **Download Logs byte-accurate progress dialog + non-blocking Cancel (closes #88)** —
+  `WiCANLogClient.plan()` (one home for skip decisions + `total_bytes`),
+  per-chunk `progress_cb`, `WiCANLogSync.progress_changed` + `cancel()`, a
+  non-modal `QProgressDialog` owned by the ECU window.
+- **Download Logs ⇄ ECU ops mutually exclusive** — while a download runs, every
+  ECU op + Connect lock (tooltip); the stop-first backstop remains.
+- **Removed startup auto-download** — the `schedule_auto_start()` call, the
+  `get/set_wican_auto_download_logs` setting, and its Settings toggle are gone;
+  downloads are manual-only now. Trip-logs directory setting kept.
+- Deliberately EXCLUDED from this branch (they'd drag brick-critical
+  `wican_config.py`/`session.py` in): the keepalive-log-spam quiet fix
+  (`set_bulk_transfer`/`peek_datalog_client`) and the `get_datalog_client`
+  shared-client refactor — those stay with the live-datalog branch.
+- Green: `black` clean, `flake8 src/ tests/` 0, full suite 1670 passed / 12
+  skipped. PR body must say `Closes #88`.
+
 ## ✅ #83 WiCAN TRIP-LOG SYNC — BUILT + HARDWARE-VALIDATED + SHIPPED v2.11.0 (Jul 10, 2026)
 
 Branch `feature/wican-log-sync` (off master @ v2.10.0), goal doc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to NC Flash are documented here.
 
+## [Unreleased]
+
+### Added
+- **Download Logs now shows a byte-accurate progress dialog with Cancel (#88)** — clicking **Download Logs** in the ECU Programming window pops a progress dialog driven by real bytes. A planning pass sums the device's advertised file sizes up front (the skip decisions — active trip file, already downloaded, unsafe name — now live in one place and run before the first byte), so the bar is determinate immediately; the label shows `Downloading <file>… (X.X of Y.Y MB)`. **Cancel** stops the run without freezing the GUI: files already downloaded are kept, the in-flight `.part` is cleaned up, and the next sync re-fetches only what's missing. The dialog is non-modal (it never blocks the main window or any open table window) and only the manual button raises it; the automatic launch sync path stays quiet as before. Field-motivated: a morning sync moved ~66 MB for two minutes with no visible progress and no way to stop it.
+
+### Changed
+- **Download Logs and ECU operations are now mutually exclusive** — while a trip-log download runs, every ECU action (Flash Current / Full Flash / Read ROM / Read RAM / Read+Clear DTCs) and the Connect button are locked with an explanatory tooltip, so a download and a flash/read can never contend for the WiCAN's SD card, CPU, and WiFi at the same time. Previously only the reverse held (starting an ECU operation stopped a running download); that backstop remains for non-button code paths.
+
+### Removed
+- **Automatic trip-log download on startup** — NC Flash no longer pulls trip logs from the WiCAN at launch, and the *Settings > ECU > WiCAN > "Auto-download new trip logs on startup"* toggle has been removed. Trip logs are now downloaded only on demand via the **Download Logs** button (with the new progress dialog above). The trip-logs directory setting is unchanged.
+
 ## [v2.11.0] - 2026-07-10
 
 ### Added

--- a/main.py
+++ b/main.py
@@ -295,10 +295,6 @@ class MainWindow(
         if self.settings.get_mcp_auto_start():
             self._start_mcp_server()
 
-        # Auto-download new WiCAN trip logs, silently and off the GUI thread
-        # (the sync owner defers it and honors its own enable setting).
-        self.wican_log_sync.schedule_auto_start()
-
     def check_metadata_directory(self) -> bool:
         """
         Check if metadata directory is configured and valid

--- a/main.py
+++ b/main.py
@@ -194,8 +194,8 @@ class MainWindow(
         self.ecu_window = None
 
         # WiCAN trip-log sync — single owner of the background download state,
-        # shared by the launch-time auto-download and the ECU window's
-        # Download Logs button (pure HTTP device utility; no ECU session).
+        # driven by the ECU window's Download Logs button (pure HTTP device
+        # utility; no ECU session).
         self.wican_log_sync = WiCANLogSync(self.settings, parent=self)
 
         # MCP server subprocess

--- a/src/ecu/wican_http.py
+++ b/src/ecu/wican_http.py
@@ -107,6 +107,7 @@ def download_to_file(
     expected_size: Optional[int] = None,
     timeout_s: float = DEFAULT_TIMEOUT_S,
     abort_cb=None,
+    progress_cb=None,
 ) -> Path:
     """Stream *url* to *dest* atomically and return *dest*.
 
@@ -119,6 +120,10 @@ def download_to_file(
     ``abort_cb`` (no-arg, returns truthy to abort) is polled between chunks so
     a worker thread can be stopped promptly at app exit; an abort cleans up the
     ``.part`` file and raises like any other failure.
+
+    ``progress_cb`` (one arg: cumulative bytes received so far) is invoked
+    after every chunk lands on disk, so a caller can drive a byte-accurate
+    progress display for large trip logs.
     """
     dest = Path(dest)
     dest.parent.mkdir(parents=True, exist_ok=True)
@@ -136,6 +141,8 @@ def download_to_file(
                         break
                     fh.write(chunk)
                     received += len(chunk)
+                    if progress_cb is not None:
+                        progress_cb(received)
     except WiCANHttpError:
         _remove_quietly(part)
         raise

--- a/src/ecu/wican_logs.py
+++ b/src/ecu/wican_logs.py
@@ -83,6 +83,21 @@ class LogSyncResult:
     skipped: list = field(default_factory=list)  # list[str] remote names
 
 
+@dataclass(frozen=True)
+class SyncPlan:
+    """What one sync run will actually transfer, decided before the first byte.
+
+    Produced by :meth:`WiCANLogClient.plan` — the ONE place the skip decisions
+    (unsafe name, active trip file, already downloaded) live. ``total_bytes``
+    is the sum of the sizes ``/csv_list`` advertised for ``to_download``, so a
+    progress display is byte-accurate from the start.
+    """
+
+    to_download: list = field(default_factory=list)  # list[(TripLog, Path)]
+    skipped: list = field(default_factory=list)  # list[str] remote names
+    total_bytes: int = 0
+
+
 class WiCANLogClient:
     """Downloads new SD trip logs from a WiCAN into a local directory."""
 
@@ -146,25 +161,13 @@ class WiCANLogClient:
 
     # --- the sync ------------------------------------------------------------
 
-    def download_new(
-        self, dest_dir, *, skip_active: bool = True, abort_cb=None
-    ) -> LogSyncResult:
-        """Download every remote log not yet present locally into *dest_dir*.
+    def plan(self, dest_dir, *, skip_active: bool = True) -> SyncPlan:
+        """Decide what a sync run will download, without transferring anything.
 
         Skips (in ``skipped``, by remote name): logs already present with the
         same size (under the original or a ``-N`` collision-suffixed name),
         the active trip file when *skip_active*, and logs whose device name
         fails sanitization (warned, never trusted).
-
-        ``abort_cb`` (no-arg, returns truthy to abort) is polled between files
-        and between download chunks; an abort returns the partial result —
-        completed files remain and the run stays idempotent.
-
-        Raises :class:`~src.ecu.wican_http.WiCANHttpError` (or its
-        :class:`WiCANLogsError` subclass for malformed device replies) when
-        the device is unreachable or a transfer fails mid-run; files
-        downloaded before the failure remain (the run is idempotent —
-        re-running downloads only what is missing).
         """
         dest_dir = Path(dest_dir)
         logs = self.list_logs()
@@ -175,46 +178,124 @@ class WiCANLogClient:
             # is the risk — fail the run rather than guess.
             active = self.active_log_basename()
 
-        result = LogSyncResult()
+        to_download = []
+        skipped = []
+        total_bytes = 0
+        # Targets already promised to an earlier log THIS run. The whole plan
+        # resolves against pre-run disk state, so without this a collision-
+        # suffixed name could land on a later log's literal name and the two
+        # downloads would silently clobber each other.
+        reserved = set()
         for log in logs:
+            try:
+                name = sanitize_basename(log.name)
+            except WiCANHttpError as exc:
+                logger.warning("Skipping device log with unsafe name: %s", exc)
+                skipped.append(log.name)
+                continue
+
+            if active is not None and name == active:
+                logger.info("Skipping active trip file %s (still being written)", name)
+                skipped.append(log.name)
+                continue
+
+            target = self._resolve_target(dest_dir, name, log.size, reserved)
+            if target is None:
+                skipped.append(log.name)  # already downloaded
+                continue
+
+            reserved.add(target)
+            to_download.append((log, target))
+            total_bytes += log.size
+
+        return SyncPlan(
+            to_download=to_download, skipped=skipped, total_bytes=total_bytes
+        )
+
+    def download_new(
+        self, dest_dir, *, skip_active: bool = True, abort_cb=None, progress_cb=None
+    ) -> LogSyncResult:
+        """Download every remote log not yet present locally into *dest_dir*.
+
+        The skip decisions live in :meth:`plan`; ``skipped`` in the result is
+        the plan's skip list.
+
+        ``abort_cb`` (no-arg, returns truthy to abort) is polled between files
+        and between download chunks; an abort returns the partial result —
+        completed files remain and the run stays idempotent.
+
+        ``progress_cb`` (three args: cumulative bytes done across the whole
+        run, total bytes the plan will transfer, name of the file currently
+        transferring) is invoked once up front as ``(0, total, "")`` — so a
+        progress display is determinate before the first byte — then after
+        every chunk.
+
+        Raises :class:`~src.ecu.wican_http.WiCANHttpError` (or its
+        :class:`WiCANLogsError` subclass for malformed device replies) when
+        the device is unreachable or a transfer fails mid-run; files
+        downloaded before the failure remain (the run is idempotent —
+        re-running downloads only what is missing).
+        """
+        sync_plan = self.plan(dest_dir, skip_active=skip_active)
+
+        result = LogSyncResult(skipped=list(sync_plan.skipped))
+        total = sync_plan.total_bytes
+        if progress_cb is not None:
+            progress_cb(0, total, "")
+
+        base = 0  # bytes of fully-downloaded files so far
+        for log, target in sync_plan.to_download:
             if abort_cb is not None and abort_cb():
                 logger.info(
                     "Trip-log sync aborted; keeping %d downloaded file(s)",
                     len(result.downloaded),
                 )
                 break
-            try:
-                name = sanitize_basename(log.name)
-            except WiCANHttpError as exc:
-                logger.warning("Skipping device log with unsafe name: %s", exc)
-                result.skipped.append(log.name)
-                continue
 
-            if active is not None and name == active:
-                logger.info("Skipping active trip file %s (still being written)", name)
-                result.skipped.append(log.name)
-                continue
-
-            target = self._resolve_target(dest_dir, name, log.size)
-            if target is None:
-                result.skipped.append(log.name)  # already downloaded
-                continue
+            per_file_cb = None
+            if progress_cb is not None:
+                per_file_cb = self._file_progress(progress_cb, base, total, log.name)
 
             url = self._url(CSV_DOWNLOAD_PATH, {"file": log.name})
-            path = download_to_file(
-                url,
-                target,
-                expected_size=log.size,
-                timeout_s=self.timeout_s,
-                abort_cb=abort_cb,
-            )
+            try:
+                path = download_to_file(
+                    url,
+                    target,
+                    expected_size=log.size,
+                    timeout_s=self.timeout_s,
+                    abort_cb=abort_cb,
+                    progress_cb=per_file_cb,
+                )
+            except WiCANHttpError:
+                if abort_cb is not None and abort_cb():
+                    # A mid-file cancel surfaces as the aborted-download error;
+                    # the user asked for this — return the partial result like
+                    # a between-files abort (the .part is already cleaned up).
+                    logger.info(
+                        "Trip-log sync aborted; keeping %d downloaded file(s)",
+                        len(result.downloaded),
+                    )
+                    break
+                raise
             logger.info("Downloaded trip log %s (%d bytes)", path.name, log.size)
             result.downloaded.append(path)
+            base += log.size
 
         return result
 
     @staticmethod
-    def _resolve_target(dest_dir: Path, name: str, size: int) -> Optional[Path]:
+    def _file_progress(progress_cb, base: int, total: int, name: str):
+        """Adapt the per-chunk byte count of one file to whole-run progress."""
+
+        def cb(received: int):
+            progress_cb(base + received, total, name)
+
+        return cb
+
+    @staticmethod
+    def _resolve_target(
+        dest_dir: Path, name: str, size: int, reserved=frozenset()
+    ) -> Optional[Path]:
         """Pick the local path for a remote log, honoring the collision guard.
 
         Returns None when a local copy with the same size already exists (under
@@ -222,6 +303,10 @@ class WiCANLogClient:
         returns the first free path: ``name``, else ``stem-2.ext``, ``-3``, …
         (clockless devices reuse names across reboots; never clobber a
         different file, never re-download an existing one).
+
+        ``reserved`` holds paths already promised to other logs in the same
+        planning pass (not yet on disk) — treated as occupied so two logs in
+        one run can never resolve to the same target.
         """
         plain = dest_dir / name
         stem, dot, ext = name.rpartition(".")
@@ -230,13 +315,16 @@ class WiCANLogClient:
 
         candidate = plain
         for n in range(2, _MAX_COLLISION_SUFFIX + 1):
-            if not candidate.exists():
+            if candidate in reserved:
+                pass  # promised to another log this run — probe the next name
+            elif not candidate.exists():
                 return candidate
-            try:
-                if candidate.stat().st_size == size:
-                    return None  # same trip already downloaded
-            except OSError:
-                pass  # race/unreadable — treat as occupied, probe the next name
+            else:
+                try:
+                    if candidate.stat().st_size == size:
+                        return None  # same trip already downloaded
+                except OSError:
+                    pass  # race/unreadable — treat as occupied, probe the next
             candidate = dest_dir / (f"{stem}-{n}.{ext}" if ext else f"{stem}-{n}")
         raise WiCANLogsError(
             f"More than {_MAX_COLLISION_SUFFIX} local name collisions for "

--- a/src/ecu/wican_logs.py
+++ b/src/ecu/wican_logs.py
@@ -243,13 +243,16 @@ class WiCANLogClient:
         if progress_cb is not None:
             progress_cb(0, total, "")
 
+        def _log_abort():
+            logger.info(
+                "Trip-log sync aborted; keeping %d downloaded file(s)",
+                len(result.downloaded),
+            )
+
         base = 0  # bytes of fully-downloaded files so far
         for log, target in sync_plan.to_download:
             if abort_cb is not None and abort_cb():
-                logger.info(
-                    "Trip-log sync aborted; keeping %d downloaded file(s)",
-                    len(result.downloaded),
-                )
+                _log_abort()
                 break
 
             per_file_cb = None
@@ -271,10 +274,7 @@ class WiCANLogClient:
                     # A mid-file cancel surfaces as the aborted-download error;
                     # the user asked for this — return the partial result like
                     # a between-files abort (the .part is already cleaned up).
-                    logger.info(
-                        "Trip-log sync aborted; keeping %d downloaded file(s)",
-                        len(result.downloaded),
-                    )
+                    _log_abort()
                     break
                 raise
             logger.info("Downloaded trip log %s (%d bytes)", path.name, log.size)

--- a/src/ui/ecu_window.py
+++ b/src/ui/ecu_window.py
@@ -21,6 +21,7 @@ from PySide6.QtWidgets import (
     QLabel,
     QPushButton,
     QProgressBar,
+    QProgressDialog,
     QStackedWidget,
     QMessageBox,
     QFileDialog,
@@ -188,6 +189,14 @@ class ECUProgrammingWindow(QMainWindow):
         # Re-gate the Download Logs button as the main-window-owned sync
         # starts/stops (Qt auto-disconnects when this window is destroyed).
         main_window.wican_log_sync.running_changed.connect(self._update_action_states)
+        # The download progress dialog (exists only for a sync started from
+        # THIS window's button; launch auto-syncs stay dialog-free by the
+        # sync's quiet-by-contract rule).
+        self._download_progress = None
+        main_window.wican_log_sync.progress_changed.connect(self._on_download_progress)
+        main_window.wican_log_sync.running_changed.connect(
+            self._on_download_sync_running
+        )
 
         self._update_action_states()
 
@@ -312,6 +321,7 @@ class ECUProgrammingWindow(QMainWindow):
         row.addWidget(self._btn_download_logs)
 
         actions_layout.addLayout(row)
+
         self._stack.addWidget(actions_page)
 
         # Page 1: Progress
@@ -673,25 +683,48 @@ class ECUProgrammingWindow(QMainWindow):
 
         # Download Logs is a WiCAN device utility (pure HTTP, no ECU session):
         # shown only when the WiCAN adapter is selected (with Tactrix/J2534 the
-        # SD card is a manual operation, so the button is hidden entirely).
-        # Available without a connection, but held off while an ECU operation
-        # runs (don't contend with a flash for the device's SD/CPU) or while a
-        # sync is already in flight.
+        # SD card is a manual operation, so it is hidden entirely). It contends
+        # with every ECU operation for the device's SD/CPU/WiFi, so the two
+        # never mix: while a download runs, everything else on this page locks.
         is_wican_adapter = self._main_window.settings.is_wican_adapter()
         log_sync = self._main_window.wican_log_sync
+        utility_running = log_sync.is_running
+        wican_contended = is_wican_adapter and utility_running
+
         self._btn_download_logs.setVisible(is_wican_adapter)
         self._btn_download_logs.setEnabled(
-            is_wican_adapter and not log_sync.is_running and not busy
+            is_wican_adapter and not utility_running and not busy
         )
 
-        # Nothing works while an operation is in progress
-        if busy:
+        # An ECU connect during a download would contend for the WiCAN's
+        # SD/CPU/WiFi (and connecting re-parks the datalogger). Gate Connect
+        # like the op buttons, but only while fully DISCONNECTED:
+        # mid-connect/connected states own the button elsewhere.
+        # (getattr: session test doubles may expose is_connected only.)
+        disconnected = self._session is None or (
+            getattr(self._session, "state", None) == ECUSessionState.DISCONNECTED
+        )
+        if is_wican_adapter and disconnected:
+            self._btn_connect.setEnabled(not utility_running)
+
+        # Nothing works while an operation is in progress, and no ECU
+        # operation may start while a download holds the WiCAN.
+        if busy or wican_contended:
             self._btn_read_dtcs.setEnabled(False)
             self._btn_clear_dtcs.setEnabled(False)
             self._btn_full_flash.setEnabled(False)
             self._btn_read_rom.setEnabled(False)
             self._btn_scan_ram.setEnabled(False)
             self._btn_flash_current.setEnabled(False)
+            tip = (
+                "Stop the WiCAN trip-log download first"
+                if wican_contended and not busy
+                else ""
+            )
+            self._btn_full_flash.setToolTip(tip)
+            self._btn_read_rom.setToolTip(tip)
+            self._btn_scan_ram.setToolTip(tip)
+            self._btn_flash_current.setToolTip(tip)
             return
 
         # Safe operations: just need connection
@@ -1032,8 +1065,86 @@ class ECUProgrammingWindow(QMainWindow):
         Runs entirely over HTTP on a worker thread — no ECU session, no
         progress page; per-file results land in the Activity Log below. Button
         state refresh rides the sync's ``running_changed`` signal.
+
+        A manual start (this button) gets a byte-accurate progress dialog with
+        Cancel; the launch-time auto-sync never comes through here and stays
+        dialog-free (quiet by contract). NON-modal by design: WindowModal
+        would block the main window and every table window too (it blocks the
+        parent, all grandparents, and their siblings — the 2026-07-11 freeze
+        family of mistakes), and no blocking is needed — every button this
+        run must not race is already disabled while the sync runs.
         """
-        self._main_window.wican_log_sync.start()
+        if not self._main_window.wican_log_sync.start():
+            return
+        dialog = self._create_download_progress_dialog()
+        self._download_progress = dialog
+        dialog.show()
+        dialog.raise_()
+
+    def _create_download_progress_dialog(self):
+        """Build the (unstyled, theme-safe, non-modal) download progress dialog."""
+        dialog = QProgressDialog(
+            "Checking WiCAN for new trip logs...", "Cancel", 0, 0, self
+        )
+        dialog.setWindowTitle("Download Logs")
+        # Non-modal also keeps QProgressDialog.setValue() from re-entering the
+        # event loop (it calls processEvents() only when the dialog is modal).
+        dialog.setWindowModality(Qt.NonModal)
+        dialog.setAutoClose(False)
+        dialog.setAutoReset(False)
+        dialog.setMinimumDuration(0)
+        dialog.canceled.connect(self._on_download_logs_cancel)
+        return dialog
+
+    def _on_download_progress(self, done: int, total: int, name: str):
+        """Drive the dialog from the sync's byte progress (KiB units).
+
+        KiB keeps the range far under QProgressDialog's int32 ceiling for any
+        plausible SD card content. ``total == 0`` (nothing to download) leaves
+        the bar indeterminate for the moment until the run ends.
+        """
+        dialog = self._download_progress
+        if dialog is None:
+            return
+        if total <= 0:
+            return
+        dialog.setMaximum(max(1, total // 1024))
+        dialog.setValue(min(done, total) // 1024)
+        mb_total = total / (1024 * 1024)
+        if name:
+            mb_done = min(done, total) / (1024 * 1024)
+            dialog.setLabelText(
+                f"Downloading {name}...  ({mb_done:.1f} of {mb_total:.1f} MB)"
+            )
+        else:
+            dialog.setLabelText(f"Downloading trip logs ({mb_total:.1f} MB)...")
+
+    def _on_download_logs_cancel(self):
+        """Cancel button: stop the sync without blocking the GUI thread.
+
+        The worker exits at the next 64 KiB chunk; completed files remain and
+        the run stays idempotent. Dialog teardown rides running_changed(False)
+        like every other end-of-run path.
+        """
+        dialog = self._download_progress
+        if dialog is not None:
+            dialog.setLabelText("Cancelling...")
+        self._main_window.wican_log_sync.cancel()
+
+    def _on_download_sync_running(self, running: bool):
+        """Close the progress dialog when the sync ends (any path).
+
+        Completion, error, and cancel all funnel through running_changed(False);
+        auto-syncs with no dialog make this a no-op.
+        """
+        if running:
+            return
+        dialog = self._download_progress
+        if dialog is None:
+            return
+        self._download_progress = None
+        dialog.close()
+        dialog.deleteLater()
 
     def _build_flash_driver(self, operation: str, source_name: str | None = None):
         """Select and prepare the flash/read driver for the current adapter.
@@ -1125,7 +1236,8 @@ class ECUProgrammingWindow(QMainWindow):
         # every ECU operation routed through the device — stop it first (fast
         # abort between chunks; completed files remain, the rest re-fetch on
         # the next sync). J2534 ops don't touch the WiCAN, so they leave a
-        # running sync alone.
+        # running sync alone. _update_action_states locks the ECU buttons
+        # while a utility runs, so this is the backstop for non-button paths.
         log_sync = self._main_window.wican_log_sync
         if self._is_wican() and log_sync.is_running:
             logger.info("Stopping WiCAN trip-log sync for the ECU operation")

--- a/src/ui/ecu_window.py
+++ b/src/ui/ecu_window.py
@@ -189,9 +189,8 @@ class ECUProgrammingWindow(QMainWindow):
         # Re-gate the Download Logs button as the main-window-owned sync
         # starts/stops (Qt auto-disconnects when this window is destroyed).
         main_window.wican_log_sync.running_changed.connect(self._update_action_states)
-        # The download progress dialog (exists only for a sync started from
-        # THIS window's button; launch auto-syncs stay dialog-free by the
-        # sync's quiet-by-contract rule).
+        # The download progress dialog, created only for a sync started from
+        # THIS window's Download Logs button (None otherwise).
         self._download_progress = None
         main_window.wican_log_sync.progress_changed.connect(self._on_download_progress)
         main_window.wican_log_sync.running_changed.connect(
@@ -311,7 +310,7 @@ class ECUProgrammingWindow(QMainWindow):
         # WiCAN device utility, NOT an ECU operation: pure HTTP to the WiCAN's
         # port-80 log endpoints — needs no ECU connection and works whichever
         # adapter is selected. The sync itself is owned by the main window's
-        # WiCANLogSync collaborator (shared with the launch-time auto-download).
+        # WiCANLogSync collaborator.
         self._btn_download_logs = QPushButton("Download Logs")
         self._btn_download_logs.setMinimumHeight(36)
         self._btn_download_logs.setToolTip(
@@ -688,12 +687,12 @@ class ECUProgrammingWindow(QMainWindow):
         # never mix: while a download runs, everything else on this page locks.
         is_wican_adapter = self._main_window.settings.is_wican_adapter()
         log_sync = self._main_window.wican_log_sync
-        utility_running = log_sync.is_running
-        wican_contended = is_wican_adapter and utility_running
+        sync_running = log_sync.is_running
+        wican_contended = is_wican_adapter and sync_running
 
         self._btn_download_logs.setVisible(is_wican_adapter)
         self._btn_download_logs.setEnabled(
-            is_wican_adapter and not utility_running and not busy
+            is_wican_adapter and not sync_running and not busy
         )
 
         # An ECU connect during a download would contend for the WiCAN's
@@ -705,7 +704,7 @@ class ECUProgrammingWindow(QMainWindow):
             getattr(self._session, "state", None) == ECUSessionState.DISCONNECTED
         )
         if is_wican_adapter and disconnected:
-            self._btn_connect.setEnabled(not utility_running)
+            self._btn_connect.setEnabled(not sync_running)
 
         # Nothing works while an operation is in progress, and no ECU
         # operation may start while a download holds the WiCAN.
@@ -1066,13 +1065,12 @@ class ECUProgrammingWindow(QMainWindow):
         progress page; per-file results land in the Activity Log below. Button
         state refresh rides the sync's ``running_changed`` signal.
 
-        A manual start (this button) gets a byte-accurate progress dialog with
-        Cancel; the launch-time auto-sync never comes through here and stays
-        dialog-free (quiet by contract). NON-modal by design: WindowModal
-        would block the main window and every table window too (it blocks the
-        parent, all grandparents, and their siblings — the 2026-07-11 freeze
-        family of mistakes), and no blocking is needed — every button this
-        run must not race is already disabled while the sync runs.
+        The button gets a byte-accurate progress dialog with Cancel. NON-modal
+        by design: WindowModal would block the main window and every table
+        window too (it blocks the parent, all grandparents, and their siblings
+        — the 2026-07-11 freeze family of mistakes), and no blocking is needed
+        — every button this run must not race is already disabled while the
+        sync runs.
         """
         if not self._main_window.wican_log_sync.start():
             return
@@ -1108,11 +1106,12 @@ class ECUProgrammingWindow(QMainWindow):
             return
         if total <= 0:
             return
+        done = min(done, total)
         dialog.setMaximum(max(1, total // 1024))
-        dialog.setValue(min(done, total) // 1024)
+        dialog.setValue(done // 1024)
         mb_total = total / (1024 * 1024)
         if name:
-            mb_done = min(done, total) / (1024 * 1024)
+            mb_done = done / (1024 * 1024)
             dialog.setLabelText(
                 f"Downloading {name}...  ({mb_done:.1f} of {mb_total:.1f} MB)"
             )
@@ -1134,8 +1133,10 @@ class ECUProgrammingWindow(QMainWindow):
     def _on_download_sync_running(self, running: bool):
         """Close the progress dialog when the sync ends (any path).
 
-        Completion, error, and cancel all funnel through running_changed(False);
-        auto-syncs with no dialog make this a no-op.
+        Completion, error, and cancel all funnel through running_changed(False).
+        The dialog-None guard keeps this a no-op for any sync not started from
+        this button (e.g. the synchronous running_changed(True) that fires
+        inside start() before _on_download_logs assigns the dialog).
         """
         if running:
             return

--- a/src/ui/settings_dialog.py
+++ b/src/ui/settings_dialog.py
@@ -393,22 +393,6 @@ SETTINGS_REGISTRY = [
         setter=None,
     ),
     SettingDescriptor(
-        key="ecu.wican.auto_download_logs",
-        label="Auto-download new trip logs on startup",
-        description=(
-            "At app launch, silently pull new datalog CSVs from the WiCAN's SD "
-            "card into the trip logs directory below. Only active while the "
-            "WiCAN adapter is selected; skipped quietly when the device is "
-            "asleep or unreachable; never deletes from the device."
-        ),
-        category="ECU",
-        subcategory="WiCAN",
-        widget_type="checkbox",
-        getter="get_wican_auto_download_logs",
-        setter="set_wican_auto_download_logs",
-        keywords=["wican", "logs", "datalog", "csv", "download", "trip", "auto"],
-    ),
-    SettingDescriptor(
         key="ecu.wican.logs_dir",
         label="Trip Logs Directory",
         description="Local folder where WiCAN trip logs (.csv) are downloaded",

--- a/src/ui/wican_log_sync.py
+++ b/src/ui/wican_log_sync.py
@@ -19,11 +19,16 @@ a worker QThread; the GUI thread is never blocked.
 """
 
 import logging
+import time
 from typing import Optional
 
-from PySide6.QtCore import QObject, QThread, Qt, QTimer, Signal
+from PySide6.QtCore import QObject, QThread, Qt, Signal
 
 logger = logging.getLogger(__name__)
+
+#: Progress emits are throttled to this period (a 27 MB trip log arrives in
+#: ~420 chunks; flooding queued cross-thread signals helps nobody).
+_PROGRESS_MIN_INTERVAL_S = 0.1
 
 
 class _LogSyncWorker(QObject):
@@ -31,6 +36,8 @@ class _LogSyncWorker(QObject):
 
     finished = Signal(object)  # LogSyncResult
     error = Signal(str)
+    #: (bytes_done, bytes_total, filename currently transferring)
+    progress = Signal(int, int, str)
 
     def __init__(
         self,
@@ -44,6 +51,7 @@ class _LogSyncWorker(QObject):
         self._device_id = device_id
         self._dest_dir = dest_dir
         self._http_port = http_port  # None -> the client's device default
+        self._last_progress_emit = 0.0
 
     def run(self):
         try:
@@ -58,12 +66,30 @@ class _LogSyncWorker(QObject):
             )
             kwargs = {} if self._http_port is None else {"http_port": self._http_port}
             client = WiCANLogClient(host, **kwargs)
-            result = client.download_new(self._dest_dir, abort_cb=self._abort_requested)
+
+            result = client.download_new(
+                self._dest_dir,
+                abort_cb=self._abort_requested,
+                progress_cb=self._on_progress,
+            )
             self.finished.emit(result)
         except Exception as e:
             # Device asleep/unreachable is a normal condition — the owner logs
             # it quietly; nothing may raise out of a Qt worker slot.
             self.error.emit(str(e))
+
+    def _on_progress(self, done: int, total: int, name: str):
+        """Forward download progress as a signal, throttled to ~10 Hz.
+
+        Boundary emits (run start, file completion) always pass so the display
+        never misses the determinate total or the final 100%.
+        """
+        now = time.monotonic()
+        boundary = done == 0 or done >= total
+        if not boundary and now - self._last_progress_emit < _PROGRESS_MIN_INTERVAL_S:
+            return
+        self._last_progress_emit = now
+        self.progress.emit(done, total, name)
 
     @staticmethod
     def _abort_requested() -> bool:
@@ -77,8 +103,10 @@ class WiCANLogSync(QObject):
     #: True while a sync runs (drives the Download Logs button state).
     running_changed = Signal(bool)
 
-    #: Launch auto-sync defer — long enough to never compete with startup I/O.
-    _AUTO_START_DELAY_MS = 3000
+    #: Byte progress of the running sync: (bytes_done, bytes_total, filename).
+    #: Fires (0, total, "") as soon as the plan is known — a consumer can show
+    #: a determinate bar before the first byte — then ~10 Hz during transfers.
+    progress_changed = Signal(int, int, str)
 
     def __init__(self, settings, parent=None, *, http_port: Optional[int] = None):
         """``http_port`` overrides the client's device default (tests only)."""
@@ -91,18 +119,6 @@ class WiCANLogSync(QObject):
     @property
     def is_running(self) -> bool:
         return self._thread is not None and self._thread.isRunning()
-
-    def schedule_auto_start(self):
-        """Schedule the once-per-launch auto-download, honoring its setting.
-
-        Deferred a few seconds so it never competes with startup; a missing or
-        sleeping WiCAN then degrades to a quiet log line (most launches have
-        no device on the LAN). The composition root just calls this — the
-        enable toggle and the delay are this owner's policy.
-        """
-        if not self._settings.get_wican_auto_download_logs():
-            return
-        QTimer.singleShot(self._AUTO_START_DELAY_MS, self.start)
 
     def start(self) -> bool:
         """Kick a background sync.
@@ -138,6 +154,7 @@ class WiCANLogSync(QObject):
         # window's flash-worker wiring.
         worker.finished.connect(self._on_finished, Qt.QueuedConnection)
         worker.error.connect(self._on_error, Qt.QueuedConnection)
+        worker.progress.connect(self._on_progress, Qt.QueuedConnection)
         thread.started.connect(worker.run)
         worker.finished.connect(thread.quit)
         worker.error.connect(thread.quit)
@@ -147,6 +164,20 @@ class WiCANLogSync(QObject):
         thread.start()
         self.running_changed.emit(True)
         return True
+
+    def cancel(self):
+        """Request a running sync to stop, without blocking (Cancel button).
+
+        Sets the interruption flag and returns at once; the worker exits at the
+        next chunk/file boundary and the normal ``finished`` →
+        ``running_changed(False)`` teardown follows. Completed files remain
+        (idempotent re-run); a partial ``.part`` file is cleaned up. No-op when
+        nothing runs.
+        """
+        thread = self._thread
+        if thread is not None:
+            logger.info("Cancelling WiCAN trip-log sync...")
+            thread.requestInterruption()
 
     def shutdown(self, timeout_ms: int = 15000):
         """Stop a running sync before app exit.
@@ -180,6 +211,9 @@ class WiCANLogSync(QObject):
     def _on_error(self, message: str):
         # Sleeping/unreachable device is normal (car off): quiet info, no dialog.
         logger.info("WiCAN trip-log check skipped: %s", message)
+
+    def _on_progress(self, done: int, total: int, name: str):
+        self.progress_changed.emit(done, total, name)
 
     def _on_thread_finished(self):
         thread, worker = self._thread, self._worker

--- a/src/ui/wican_log_sync.py
+++ b/src/ui/wican_log_sync.py
@@ -1,11 +1,11 @@
 """Background WiCAN trip-log sync owner (issue #83).
 
 One :class:`WiCANLogSync` instance is owned by the main window; the ECU
-window's "Download Logs" button and the launch-time auto-download both go
-through it, so at most one sync runs at a time (state has ONE owner). The
-download itself is pure HTTP against the WiCAN's port-80 csv_logger endpoints
-— fully decoupled from the CAN bus / SLCAN session / ECU: it never opens an
-ECU connection and works whether the car is on or off.
+window's "Download Logs" button drives it, so at most one sync runs at a time
+(state has ONE owner). The download itself is pure HTTP against the WiCAN's
+port-80 csv_logger endpoints — fully decoupled from the CAN bus / SLCAN
+session / ECU: it never opens an ECU connection and works whether the car is
+on or off.
 
 Product decision (2026-07-10): the WHOLE feature is active only while the
 WiCAN adapter is selected — :meth:`WiCANLogSync.start` is a no-op with

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -315,14 +315,6 @@ class AppSettings:
     def set_wican_auto_config(self, enabled: bool):
         self.settings.setValue("ecu/wican_auto_config", bool(enabled))
 
-    def get_wican_auto_download_logs(self) -> bool:
-        """Whether to auto-download new SD trip logs at launch (no-op when no
-        WiCAN host/identity is configured)."""
-        return self.settings.value("ecu/wican_auto_download_logs", True, type=bool)
-
-    def set_wican_auto_download_logs(self, enabled: bool):
-        self.settings.setValue("ecu/wican_auto_download_logs", bool(enabled))
-
 
 # Global settings instance
 _settings = None

--- a/tests/test_ecu_wican_logs.py
+++ b/tests/test_ecu_wican_logs.py
@@ -324,6 +324,46 @@ class TestDownloadNew:
         assert result.downloaded == []
         assert list(tmp_path.iterdir()) == []
 
+    def test_abort_mid_file_returns_partial_result_not_error(self, tmp_path):
+        # A Cancel during a large file lands between CHUNKS, inside
+        # download_to_file — that must end the run like a between-files abort
+        # (partial result returned), never surface as a transfer error.
+        # The abort LATCHES once it sees the in-flight .part (deterministic:
+        # it exists the moment the transfer opens), mirroring the production
+        # signal — QThread.requestInterruption never un-requests.
+        latched = []
+
+        def abort_cb():
+            if latched or (tmp_path / "big.csv.part").exists():
+                latched.append(True)
+            return bool(latched)
+
+        files = {"big.csv": b"x" * (128 * 1024), "next.csv": b"y" * 16}
+        with _device(files) as (client, _):
+            result = client.download_new(tmp_path, abort_cb=abort_cb)
+        assert result.downloaded == []
+        assert not (tmp_path / "big.csv").exists()
+        assert not (tmp_path / "next.csv").exists()  # run really ended
+        _no_part_residue(tmp_path)
+
+    def test_intra_run_collision_never_clobbers(self, tmp_path):
+        # Data-loss regression guard: the plan resolves every target against
+        # PRE-RUN disk state, so a collision-suffixed name ("t.csv" bumped to
+        # "t-2.csv" past a stale local copy) must never land on another remote
+        # log's literal name in the same run — the plan reserves each target.
+        (tmp_path / "t.csv").write_bytes(b"z" * 100)  # older trip, same name
+        files = {"t.csv": b"a" * 200, "t-2.csv": b"b" * 300}
+        with _device(files) as (client, _):
+            plan = client.plan(tmp_path)
+            targets = [target for _, target in plan.to_download]
+            assert len(set(targets)) == len(targets) == 2  # distinct targets
+            result = client.download_new(tmp_path)
+        assert len(result.downloaded) == 2
+        # Every byte of both trips is on disk; the stale local copy untouched.
+        assert (tmp_path / "t.csv").read_bytes() == b"z" * 100
+        on_disk = sorted(p.read_bytes() for p in result.downloaded)
+        assert on_disk == [b"a" * 200, b"b" * 300]
+
     def test_empty_device_is_quiet(self, tmp_path):
         with _device({}) as (client, _):
             result = client.download_new(tmp_path)
@@ -352,6 +392,58 @@ class TestDownloadNew:
             httpd.shutdown()
             httpd.server_close()
             t.join(timeout=2)
+
+
+# --- byte progress (plan + per-chunk callbacks) ---------------------------------
+
+
+class TestDownloadProgress:
+    def test_download_to_file_reports_cumulative_bytes(self, tmp_path):
+        data = b"x" * (150 * 1024)  # spans multiple 64 KiB chunks
+        seen = []
+        with _device({"a.csv": data}) as (client, _):
+            download_to_file(
+                client._url("/download_csv", {"file": "a.csv"}),
+                tmp_path / "a.csv",
+                expected_size=len(data),
+                progress_cb=seen.append,
+            )
+        assert len(seen) >= 2  # more than one chunk actually reported
+        assert seen == sorted(seen)  # cumulative, monotonic
+        assert seen[-1] == len(data)
+
+    def test_plan_totals_exclude_all_skips(self, tmp_path):
+        # total_bytes must count ONLY what will transfer: not the active trip
+        # file, not an already-downloaded copy, not an unsafe device name.
+        (tmp_path / "have.csv").write_bytes(b"12345")
+        files = {
+            "open.csv": b"growing!",
+            "have.csv": b"54321",  # same (name, size) -> already downloaded
+            "../evil.csv": b"pwn",
+            "new.csv": b"fresh data\n" * 3,
+        }
+        with _device(files, active="/sdcard/logs/open.csv") as (client, _):
+            plan = client.plan(tmp_path)
+        assert [log.name for log, _ in plan.to_download] == ["new.csv"]
+        assert sorted(plan.skipped) == sorted(["../evil.csv", "have.csv", "open.csv"])
+        assert plan.total_bytes == len(files["new.csv"])
+
+    def test_download_new_progress_spans_the_whole_run(self, tmp_path):
+        files = {"b.csv": b"n" * 3000, "a.csv": b"o" * 1000}
+        events = []
+        with _device(files) as (client, _):
+            client.download_new(
+                tmp_path, progress_cb=lambda d, t, n: events.append((d, t, n))
+            )
+        total = 4000
+        # Determinate before the first byte, complete at the end, one shared
+        # total throughout, monotonic byte counts, per-file attribution.
+        assert events[0] == (0, total, "")
+        assert events[-1] == (total, total, "a.csv")
+        assert all(t == total for _, t, _ in events)
+        dones = [d for d, _, _ in events]
+        assert dones == sorted(dones)
+        assert (3000, total, "b.csv") in events
 
 
 # --- settings / workspace plumbing ---------------------------------------------
@@ -384,12 +476,6 @@ class TestLogsPlumbing:
         from pathlib import Path
 
         assert Path(settings.get_logs_directory()).name == "logs"
-
-    def test_auto_download_defaults_on_and_round_trips(self, _settings):
-        settings, store = _settings
-        assert settings.get_wican_auto_download_logs() is True
-        settings.set_wican_auto_download_logs(False)
-        assert store["ecu/wican_auto_download_logs"] is False
 
     def test_is_wican_adapter_tracks_adapter_selection(self, _settings):
         # The single predicate for WiCAN-only affordances — callers never

--- a/tests/test_ecu_window_download_logs.py
+++ b/tests/test_ecu_window_download_logs.py
@@ -1,9 +1,12 @@
-"""Download Logs button gating: WiCAN-only visibility + busy/sync disable.
+"""WiCAN device-utility button gating: Download Logs.
 
-The button is a WiCAN device utility (pure HTTP to the adapter's SD log
-endpoints). With Tactrix/J2534 selected the SD card is a manual operation, so
-the button must be HIDDEN entirely — not just disabled. Exercised against a
-duck-typed fake ``self`` (mirrors ``test_ecu_read_naming``) — no QApplication.
+Download Logs is a WiCAN device utility (pure HTTP to the adapter, no ECU
+session). With Tactrix/J2534 selected it must be HIDDEN entirely — not just
+disabled. The utility and ECU operations never mix: while a download runs,
+every ECU action locks (with an explanatory tooltip) and Connect is held off
+while disconnected. It is also held off while an ECU operation is busy.
+Exercised against a duck-typed fake ``self`` (mirrors ``test_ecu_read_naming``)
+— no QApplication.
 """
 
 from types import SimpleNamespace
@@ -11,8 +14,15 @@ from unittest.mock import MagicMock
 
 from src.ui.ecu_window import ECUProgrammingWindow
 
+UTILITY_LOCK_TIP = "Stop the WiCAN trip-log download first"
 
-def _fake_window(adapter="wican", sync_running=False, ecu_busy=False):
+
+def _fake_window(
+    adapter="wican",
+    sync_running=False,
+    ecu_busy=False,
+    connected=False,
+):
     settings = MagicMock()
     settings.is_wican_adapter.return_value = adapter == "wican"
     main_window = SimpleNamespace(
@@ -21,7 +31,7 @@ def _fake_window(adapter="wican", sync_running=False, ecu_busy=False):
         get_current_document=lambda: None,
     )
     return SimpleNamespace(
-        _session=None,
+        _session=SimpleNamespace(is_connected=True) if connected else None,
         _flash_thread=None,
         _ecu_busy=ecu_busy,
         _rpm=None,
@@ -34,6 +44,7 @@ def _fake_window(adapter="wican", sync_running=False, ecu_busy=False):
         _btn_scan_ram=MagicMock(),
         _btn_flash_current=MagicMock(),
         _btn_download_logs=MagicMock(),
+        _btn_connect=MagicMock(),
         _flash_subtitle=MagicMock(),
     )
 
@@ -56,7 +67,7 @@ def test_visible_and_enabled_with_wican_adapter():
     fake._btn_download_logs.setEnabled.assert_called_with(True)
 
 
-def test_disabled_but_visible_while_sync_running():
+def test_download_disabled_but_visible_while_sync_running():
     fake = _fake_window(adapter="wican", sync_running=True)
     _update(fake)
     fake._btn_download_logs.setVisible.assert_called_with(True)
@@ -68,3 +79,137 @@ def test_disabled_but_visible_while_ecu_busy():
     _update(fake)
     fake._btn_download_logs.setVisible.assert_called_with(True)
     fake._btn_download_logs.setEnabled.assert_called_with(False)
+
+
+def test_ecu_ops_locked_while_sync_running():
+    # The utility and ECU operations never mix: a running trip-log download
+    # locks every ECU action even with a live connection, and the lock
+    # explains itself via the tooltip.
+    fake = _fake_window(adapter="wican", sync_running=True, connected=True)
+    _update(fake)
+    fake._btn_read_dtcs.setEnabled.assert_called_with(False)
+    fake._btn_clear_dtcs.setEnabled.assert_called_with(False)
+    fake._btn_full_flash.setEnabled.assert_called_with(False)
+    fake._btn_read_rom.setEnabled.assert_called_with(False)
+    fake._btn_scan_ram.setEnabled.assert_called_with(False)
+    fake._btn_flash_current.setEnabled.assert_called_with(False)
+    fake._btn_flash_current.setToolTip.assert_called_with(UTILITY_LOCK_TIP)
+    fake._btn_full_flash.setToolTip.assert_called_with(UTILITY_LOCK_TIP)
+
+
+def test_ecu_ops_unlocked_when_no_utility_runs():
+    # Control for the test above: the same connected window with no utility
+    # running leaves connection-gated ops (DTCs) enabled — proving they
+    # exercise the utility lock, not the no-connection gate.
+    fake = _fake_window(adapter="wican", connected=True)
+    _update(fake)
+    fake._btn_read_dtcs.setEnabled.assert_called_with(True)
+    fake._btn_clear_dtcs.setEnabled.assert_called_with(True)
+
+
+def test_connect_locked_while_utility_runs_when_disconnected():
+    # Connecting mid-download would contend for the WiCAN's SD/CPU/WiFi (and
+    # re-park the datalogger); while DISCONNECTED the Connect button follows
+    # the utility lock.
+    fake = _fake_window(adapter="wican", sync_running=True)
+    _update(fake)
+    fake._btn_connect.setEnabled.assert_called_with(False)
+
+    fake = _fake_window(adapter="wican")
+    _update(fake)
+    fake._btn_connect.setEnabled.assert_called_with(True)
+
+
+def test_connect_untouched_while_connected():
+    # Connected (or mid-connect) states own the Connect button elsewhere —
+    # the utility lock must not fight the session-state handler for it.
+    fake = _fake_window(adapter="wican", sync_running=True, connected=True)
+    _update(fake)
+    fake._btn_connect.setEnabled.assert_not_called()
+
+
+# --- download progress dialog (manual path only) -------------------------------
+#
+# Same duck-typed-fake approach: the dialog factory is mocked so no QWidget is
+# ever constructed — these exercise the wiring, not Qt.
+
+
+def _dialog_fake(start_ok=True):
+    sync = MagicMock()
+    sync.start.return_value = start_ok
+    fake = SimpleNamespace(
+        _main_window=SimpleNamespace(wican_log_sync=sync),
+        _download_progress=None,
+        _create_download_progress_dialog=MagicMock(return_value=MagicMock()),
+    )
+    return fake, sync
+
+
+def test_download_click_shows_dialog_when_sync_starts():
+    fake, sync = _dialog_fake(start_ok=True)
+    ECUProgrammingWindow._on_download_logs(fake)
+    dialog = fake._create_download_progress_dialog.return_value
+    assert fake._download_progress is dialog
+    dialog.show.assert_called_once()
+    sync.start.assert_called_once()
+
+
+def test_download_click_no_dialog_when_start_refused():
+    # start() returning False (already running / not WiCAN / unconfigured)
+    # must not leave a zombie dialog.
+    fake, _ = _dialog_fake(start_ok=False)
+    ECUProgrammingWindow._on_download_logs(fake)
+    fake._create_download_progress_dialog.assert_not_called()
+    assert fake._download_progress is None
+
+
+def test_progress_drives_dialog_in_kib_with_mb_label():
+    fake, _ = _dialog_fake()
+    dialog = MagicMock()
+    fake._download_progress = dialog
+    two_mb, four_mb = 2 * 1024 * 1024, 4 * 1024 * 1024
+    ECUProgrammingWindow._on_download_progress(fake, two_mb, four_mb, "trip.csv")
+    dialog.setMaximum.assert_called_with(4096)
+    dialog.setValue.assert_called_with(2048)
+    label = dialog.setLabelText.call_args[0][0]
+    assert "trip.csv" in label
+    assert "2.0 of 4.0 MB" in label
+
+
+def test_progress_before_plan_or_without_dialog_is_a_noop():
+    fake, _ = _dialog_fake()
+    # Auto-sync path: signals fire with no dialog around.
+    ECUProgrammingWindow._on_download_progress(fake, 10, 100, "a.csv")
+    # total == 0 (nothing to download): bar stays as-is until the run ends.
+    dialog = MagicMock()
+    fake._download_progress = dialog
+    ECUProgrammingWindow._on_download_progress(fake, 0, 0, "")
+    dialog.setMaximum.assert_not_called()
+    dialog.setValue.assert_not_called()
+
+
+def test_cancel_relabels_and_requests_sync_cancel():
+    fake, sync = _dialog_fake()
+    dialog = MagicMock()
+    fake._download_progress = dialog
+    ECUProgrammingWindow._on_download_logs_cancel(fake)
+    dialog.setLabelText.assert_called_with("Cancelling...")
+    sync.cancel.assert_called_once()
+
+
+def test_run_end_closes_dialog_and_running_true_leaves_it():
+    fake, _ = _dialog_fake()
+    dialog = MagicMock()
+    fake._download_progress = dialog
+
+    ECUProgrammingWindow._on_download_sync_running(fake, True)
+    dialog.close.assert_not_called()
+    assert fake._download_progress is dialog
+
+    ECUProgrammingWindow._on_download_sync_running(fake, False)
+    dialog.close.assert_called_once()
+    dialog.deleteLater.assert_called_once()
+    assert fake._download_progress is None
+
+    # Auto-sync (no dialog) end: a no-op.
+    ECUProgrammingWindow._on_download_sync_running(fake, False)

--- a/tests/test_wican_log_sync.py
+++ b/tests/test_wican_log_sync.py
@@ -16,7 +16,6 @@ from unittest.mock import MagicMock
 import pytest
 from PySide6.QtCore import qInstallMessageHandler
 
-import src.ui.wican_log_sync as wican_log_sync_module
 from src.ui.wican_log_sync import WiCANLogSync
 from test_ecu_wican_logs import _Handler, _device
 
@@ -149,36 +148,42 @@ class TestWiCANLogSync:
         if dest.exists():
             assert list(dest.rglob("*.part")) == []
 
-    def test_schedule_auto_start_defers_when_enabled(
-        self, fake_settings, monkeypatch, qt_thread_guard
+    def test_progress_signal_spans_the_run(self, qtbot, fake_settings, qt_thread_guard):
+        # progress_changed must arrive on the GUI thread: determinate total
+        # up front, monotonic bytes, and a final done == total emit.
+        files = {"b.csv": b"n" * 3000, "a.csv": b"o" * 1000}
+        events = []
+        with _device(files) as (_, httpd):
+            sync = WiCANLogSync(fake_settings, http_port=httpd.server_address[1])
+            sync.progress_changed.connect(lambda d, t, n: events.append((d, t, n)))
+            assert sync.start() is True
+            _wait_sync_done(qtbot, sync)
+        assert events, "no progress events reached the GUI thread"
+        total = 4000
+        assert events[0] == (0, total, "")
+        assert events[-1] == (total, total, "a.csv")
+        dones = [d for d, _, _ in events]
+        assert dones == sorted(dones)
+
+    def test_cancel_stops_mid_run_without_blocking(
+        self, qtbot, fake_settings, qt_thread_guard, caplog
     ):
-        # The owner (not main.py) owns the launch policy: the enable toggle
-        # and the defer both live in schedule_auto_start.
-        fake_settings.get_wican_auto_download_logs.return_value = True
-        scheduled = []
-
-        class _FakeTimer:
-            @staticmethod
-            def singleShot(ms, cb):
-                scheduled.append((ms, cb))
-
-        monkeypatch.setattr(wican_log_sync_module, "QTimer", _FakeTimer)
-        sync = WiCANLogSync(fake_settings)
-        sync.schedule_auto_start()
-        assert scheduled == [(WiCANLogSync._AUTO_START_DELAY_MS, sync.start)]
-
-    def test_schedule_auto_start_honors_disabled_toggle(
-        self, fake_settings, monkeypatch, qt_thread_guard
-    ):
-        fake_settings.get_wican_auto_download_logs.return_value = False
-        scheduled = []
-
-        class _FakeTimer:
-            @staticmethod
-            def singleShot(ms, cb):
-                scheduled.append((ms, cb))
-
-        monkeypatch.setattr(wican_log_sync_module, "QTimer", _FakeTimer)
-        sync = WiCANLogSync(fake_settings)
-        sync.schedule_auto_start()
-        assert scheduled == []
+        # cancel() (the dialog's Cancel button) must return immediately and
+        # let the worker wind down through the normal finished path: back to
+        # idle, no .part residue, completed files remain — and NEVER through
+        # the error path (a deliberate cancel must not log "check skipped",
+        # whether it lands between files or mid-file between chunks).
+        files = {f"trip{i}.csv": b"x" * 2048 for i in range(50)}
+        with caplog.at_level("INFO", logger="src.ui.wican_log_sync"):
+            with _device(files) as (_, httpd):
+                sync = WiCANLogSync(fake_settings, http_port=httpd.server_address[1])
+                assert sync.start() is True
+                sync.cancel()  # non-blocking; teardown rides running_changed
+                _wait_sync_done(qtbot, sync)
+                assert not sync.is_running
+        assert "WiCAN trip-log check skipped" not in caplog.text
+        dest = Path(fake_settings.get_logs_directory())
+        if dest.exists():
+            assert list(dest.rglob("*.part")) == []
+        # Idle cancel is a no-op.
+        sync.cancel()


### PR DESCRIPTION
Adds a byte-accurate progress dialog with **Cancel** to WiCAN **Download Logs**, makes Download Logs and ECU operations mutually exclusive, and removes the startup auto-download. NC-Flash-only — no firmware changes.

- **Progress dialog + Cancel** — `plan()` sums the device's file sizes up front so the bar is determinate from the first byte; Cancel stops without freezing the GUI, keeps completed files, and cleans up the in-flight `.part`. Non-modal.
- **Download ⇄ ECU mutual exclusion** — while a download runs, every ECU op + Connect lock with a tooltip.
- **Removed startup auto-download** — the setting, its Settings toggle, and the launch call are gone; downloads are manual-only now. Trip-logs directory setting unchanged.

black clean, `flake8 src/ tests/` 0, full suite **1670 passed / 12 skipped**.

Closes #88.
