### PR TITLE
feat(ui): confirm a successful ROM patch and offer to open it

### DIFF
--- a/.claude/notes.md
+++ b/.claude/notes.md
@@ -1,5 +1,28 @@
 # Session Notes
 
+## 🔵 fix/patch-rom-success-dialog — patch success modal + open-now prompt (Jul 25, 2026)
+
+Branch off master @ 654a124. A successful patch announced itself only in the
+log console + the Result group quietly appearing, so users had no explicit
+confirmation the ROM was written.
+
+- `src/ui/patch_dialog.py`: new `_confirm_open(output_path, result)` raises a
+  modal after a successful save — "ROM patched successfully." + `Saved to:
+  <path>` + "Do you want to open it now?" (Yes default). Warning icon +
+  inline warning text when `result.crc_warnings` is non-empty. Two new public
+  attrs the caller reads after `exec()`: `patched_rom_path` / `open_requested`
+  (both RESET at the start of every `_apply_patch`, so a failed retry can't
+  leave a stale path armed). Yes → `accept()`; No → dialog stays open.
+- `src/ui/flash_mixin.py`: `_on_patch_rom` opens the ROM after `exec()` when
+  the dialog reports `open_requested`. Deliberately NOT done inside the dialog
+  — opening is MainWindow's job and a `parent()` walk would break the
+  signals-carry-context rule.
+- Tests: `tests/test_patch_dialog.py` (6) — real end-to-end patch of
+  `examples/lf9veb.bin` + `.patch` for the Yes/No paths, stale-path clearing,
+  CRC-warning message content, and both FlashMixin branches.
+- Visual check done by rendering the box off-screen and screenshotting it
+  (`tools/test_runner.py` has no command for arbitrary dialogs).
+
 ## ✅ feature/trip-logs-window — Trip Logs window, MERGED + RELEASED v2.12.0 (Jul 18, 2026)
 
 Fresh branch off master @ 191ce1f (post-#89 merge). Goal: move the trip-log /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to NC Flash are documented here.
 
+## [Unreleased]
+
+### Added
+- **Patching a ROM now confirms itself with a dialog, and offers to open the result** — a successful patch reported only to the log console and a quietly-filled Result panel, so it was easy to miss that anything had been written. The Patch ROM dialog now raises a modal ("ROM patched successfully", the full output path, and *Do you want to open it now?* with Yes/No, Yes as the default). Answering Yes closes the Patch dialog and opens the patched ROM in a new tab; No leaves the dialog open with its Result panel so another patch can be applied. When the patch carried CRC verification warnings the dialog uses the warning icon and lists the warnings inline — success is still reported, but not silently over the caveat. Opening stays MainWindow's job (the dialog only reports the user's answer back through `open_requested` / `patched_rom_path`), so no parent-walk is introduced. Tests: `tests/test_patch_dialog.py`.
+
 ## [v2.12.0] - 2026-07-18
 
 ### Added

--- a/src/ui/flash_mixin.py
+++ b/src/ui/flash_mixin.py
@@ -4,7 +4,8 @@ Flash Mixin for MainWindow
 Provides the Patch ROM dialog action.
 
 This is a mixin class — it has no __init__. It relies on MainWindow being a
-QWidget (used as the dialog parent).
+QWidget (used as the dialog parent) and providing:
+- self._open_rom_file(path) method
 
 Note: the ECU *session* is owned solely by ECUProgrammingWindow (src/ui/ecu_window.py).
 This mixin used to carry a parallel `_ecu_session` half that was never wired up
@@ -22,3 +23,8 @@ class FlashMixin:
 
         dlg = PatchRomDialog(parent=self)
         dlg.exec()
+
+        # The dialog asks the user whether to open the patched ROM; opening it
+        # is MainWindow's job, so the dialog only reports the answer back.
+        if dlg.open_requested and dlg.patched_rom_path:
+            self._open_rom_file(dlg.patched_rom_path)

--- a/src/ui/patch_dialog.py
+++ b/src/ui/patch_dialog.py
@@ -123,6 +123,11 @@ class PatchRomDialog(QDialog):
         self._stock_path = None
         self._patch_path = None
 
+        # Result handed back to the caller (FlashMixin) after exec():
+        # where the patched ROM landed, and whether the user asked to open it.
+        self.patched_rom_path = None
+        self.open_requested = False
+
     def _browse_stock(self):
         from src.utils.settings import get_settings
 
@@ -183,6 +188,8 @@ class PatchRomDialog(QDialog):
 
         # Apply patch
         self._result_group.setVisible(False)
+        self.patched_rom_path = None
+        self.open_requested = False
         try:
             result = patch_rom(stock_data, patch_data)
         except ROMValidationError as e:
@@ -231,3 +238,33 @@ class PatchRomDialog(QDialog):
         self._result_group.setVisible(True)
 
         logger.info(f"Patch applied: {stock_path} + {patch_path} -> {output_path}")
+
+        self.patched_rom_path = output_path
+        if self._confirm_open(output_path, result):
+            self.open_requested = True
+            self.accept()
+
+    def _confirm_open(self, output_path, result):
+        """
+        Announce the successful patch and ask whether to open the ROM now.
+
+        The console log alone is easy to miss, so success gets its own modal.
+        Returns True when the user wants the patched ROM opened.
+        """
+        box = QMessageBox(self)
+        box.setWindowTitle("Patch Applied")
+        box.setIcon(
+            QMessageBox.Warning if result.crc_warnings else QMessageBox.Information
+        )
+        box.setText("ROM patched successfully.")
+
+        details = f"Saved to:\n{output_path}"
+        if result.crc_warnings:
+            details += "\n\nCRC verification warning:\n" + "\n".join(
+                result.crc_warnings
+            )
+        box.setInformativeText(f"{details}\n\nDo you want to open it now?")
+
+        box.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+        box.setDefaultButton(QMessageBox.Yes)
+        return box.exec() == QMessageBox.Yes

--- a/tests/test_patch_dialog.py
+++ b/tests/test_patch_dialog.py
@@ -1,0 +1,141 @@
+"""Tests for the Patch ROM dialog's success handoff.
+
+A successful patch used to announce itself only in the log console, so the user
+had no explicit confirmation that anything happened. The dialog now raises a
+modal ("ROM patched successfully" + "open it now?") and reports the answer back
+to MainWindow, which owns ROM opening.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PySide6.QtWidgets import QApplication, QDialog, QMessageBox
+
+from src.ui.flash_mixin import FlashMixin
+from src.ui.patch_dialog import PatchRomDialog
+
+_app = QApplication.instance() or QApplication([])
+
+EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
+STOCK_ROM = EXAMPLES_DIR / "lf9veb.bin"
+PATCH_FILE = EXAMPLES_DIR / "lf9veb.patch"
+
+pytestmark = pytest.mark.skipif(
+    not (STOCK_ROM.is_file() and PATCH_FILE.is_file()),
+    reason="example ROM/patch files not available",
+)
+
+
+def _armed_dialog(output_path):
+    """A dialog with both inputs chosen and an explicit output path."""
+    dlg = PatchRomDialog()
+    dlg._stock_path = str(STOCK_ROM)
+    dlg._patch_path = str(PATCH_FILE)
+    dlg._output_edit.setText(str(output_path))
+    return dlg
+
+
+def test_success_prompts_and_opens_when_user_accepts(tmp_path):
+    """Yes → patched path recorded, open requested, dialog closes accepted."""
+    output = tmp_path / "patched.bin"
+    dlg = _armed_dialog(output)
+
+    with patch.object(QMessageBox, "exec", return_value=QMessageBox.Yes) as box:
+        dlg._apply_patch()
+
+    box.assert_called_once()
+    assert output.is_file()
+    assert dlg.patched_rom_path == str(output)
+    assert dlg.open_requested is True
+    assert dlg.result() == QDialog.Accepted
+    dlg.deleteLater()
+
+
+def test_success_prompt_declined_keeps_dialog_open(tmp_path):
+    """No → the ROM is still written, but nothing is opened and the dialog stays."""
+    output = tmp_path / "patched.bin"
+    dlg = _armed_dialog(output)
+
+    with patch.object(QMessageBox, "exec", return_value=QMessageBox.No):
+        dlg._apply_patch()
+
+    assert output.is_file()
+    assert dlg.patched_rom_path == str(output)
+    assert dlg.open_requested is False
+    assert dlg.result() != QDialog.Accepted
+    dlg.deleteLater()
+
+
+def test_failed_patch_clears_previous_success(tmp_path):
+    """A failed retry must not leave a stale patched path armed for opening."""
+    output = tmp_path / "patched.bin"
+    dlg = _armed_dialog(output)
+
+    with patch.object(QMessageBox, "exec", return_value=QMessageBox.No):
+        dlg._apply_patch()
+    assert dlg.patched_rom_path == str(output)
+
+    # Retry with a patch file that cannot apply.
+    bad_patch = tmp_path / "bad.patch"
+    bad_patch.write_bytes(b"\x00" * 16)
+    dlg._patch_path = str(bad_patch)
+
+    with patch.object(QMessageBox, "warning"), patch.object(QMessageBox, "critical"):
+        dlg._apply_patch()
+
+    assert dlg.patched_rom_path is None
+    assert dlg.open_requested is False
+    dlg.deleteLater()
+
+
+def test_prompt_surfaces_crc_warnings():
+    """A CRC-warning patch still reports success, but with the warning shown."""
+    dlg = PatchRomDialog()
+    result = SimpleNamespace(crc_warnings=["stock CRC not in database"])
+
+    captured = {}
+
+    def fake_exec(self):
+        captured["icon"] = self.icon()
+        captured["text"] = self.text()
+        captured["informative"] = self.informativeText()
+        return QMessageBox.No
+
+    with patch.object(QMessageBox, "exec", fake_exec):
+        assert dlg._confirm_open("C:/roms/out.bin", result) is False
+
+    assert captured["icon"] == QMessageBox.Warning
+    assert "successfully" in captured["text"]
+    assert "stock CRC not in database" in captured["informative"]
+    assert "C:/roms/out.bin" in captured["informative"]
+    dlg.deleteLater()
+
+
+def test_flash_mixin_opens_patched_rom():
+    """MainWindow opens the ROM only when the dialog says the user asked for it."""
+    host = SimpleNamespace(_open_rom_file=MagicMock())
+
+    dlg = MagicMock()
+    dlg.open_requested = True
+    dlg.patched_rom_path = "C:/roms/out.bin"
+
+    with patch("src.ui.patch_dialog.PatchRomDialog", return_value=dlg):
+        FlashMixin._on_patch_rom(host)
+
+    host._open_rom_file.assert_called_once_with("C:/roms/out.bin")
+
+
+def test_flash_mixin_does_not_open_when_declined():
+    """Declining the prompt leaves MainWindow untouched."""
+    host = SimpleNamespace(_open_rom_file=MagicMock())
+
+    dlg = MagicMock()
+    dlg.open_requested = False
+    dlg.patched_rom_path = "C:/roms/out.bin"
+
+    with patch("src.ui.patch_dialog.PatchRomDialog", return_value=dlg):
+        FlashMixin._on_patch_rom(host)
+
+    host._open_rom_file.assert_not_called()


### PR DESCRIPTION
## Problem

A successful ROM patch reported itself only to the log console and a quietly filled Result panel. It was easy to miss that anything had been written at all.

## Change

The Patch ROM dialog now raises a modal on success:

- "ROM patched successfully", the full output path, and **Do you want to open it now?** (Yes/No, Yes default)
- **Yes** closes the dialog and opens the patched ROM in a new tab; **No** leaves the dialog open with its Result panel so another patch can be applied
- When the patch produced CRC verification warnings, the dialog uses the warning icon and lists them inline — success is still reported, but not silently over the caveat

Opening stays `MainWindow`'s job: the dialog only reports the answer back through `open_requested` / `patched_rom_path`, so no parent-walk is introduced. The `_open_rom_file()` it relies on already exists on master and is used identically by three other mixins.

## Testing

- `tests/test_patch_dialog.py` — 6 new cases, all passing
- Full suite: **1692 passed, 12 skipped**

## Notes for review

- **This restores a modal that used to exist, and it was never a judged removal.** `d0f5d16` had a `QMessageBox` on patch success; `158467d` ("remove romdrop.exe integration") then deleted the whole file, taking the modal with it, and `9e4affb` re-created `patch_dialog.py` from scratch with the inline Result panel and no modal. So the modal was collateral of a file deletion, not a UX decision that was reversed.
- Fair question for review: the modal plus the inline Result panel may be redundant, since the panel was introduced deliberately.
- The diff includes a `.claude/notes.md` session-notes block, matching the existing sections in that file. Drop it if it should not be public.
