### PR TITLE
fix(wican): stop stranding the adapter in Bench SLCAN, and recover it (#92)

### DIFF
--- a/docs/internal/WICAN_SLCAN_STRAND_INVESTIGATION.md
+++ b/docs/internal/WICAN_SLCAN_STRAND_INVESTIGATION.md
@@ -1,5 +1,25 @@
 # WiCAN Bench SLCAN strand — open investigation (August 2026)
 
+> **STATUS 2026-08-19: the host-side fix is written and verified — see branch
+> `fix/wican-slcan-strand-92`** (`e6f4fb0` red tests, `e977ed3` bench harness, the fix commit
+> after it). All three defects were reproduced on real hardware and are now fixed and covered.
+> The instruction below not to fix anything before the tests are red has been carried out; it is
+> kept for the record, not as a live instruction.
+>
+> Two claims in the original text below were **disproved** during the work and are corrected here:
+>
+> * *"This app is the only thing that ever writes `protocol: slcan`"* — **wrong.** The device's own
+>   web UI re-sends the field on every settings save from a hidden `display:none` row, and this
+>   app's Settings > Test Connection wrote it too, with no crash-recovery breadcrumb at all.
+> * *"a brief network hiccup"* as the trigger — **unproven.** The probe succeeded 5/5 on the bench
+>   at ~0.45 s of a 1.5 s budget, and across every NC Flash log the fallback fired exactly once,
+>   with zero restore failures. The defects are real and now bench-proven, but the 2026-08-11
+>   incident remains unattributed.
+>
+> What is still open: the firmware-side work (`/host_caps`, the running mode on the boot line, a
+> flash-guarded one-click restore in the web UI, and a host-less auto-revert), which is the only
+> thing that helps against a writer that is not this copy of NC Flash.
+
 Pointer document, so a session that starts in **this** repo finds the work. The full plan,
 evidence and code anchors live in the firmware repo:
 

--- a/docs/internal/WICAN_SLCAN_STRAND_INVESTIGATION.md
+++ b/docs/internal/WICAN_SLCAN_STRAND_INVESTIGATION.md
@@ -1,0 +1,51 @@
+# WiCAN Bench SLCAN strand — open investigation (August 2026)
+
+Pointer document, so a session that starts in **this** repo finds the work. The full plan,
+evidence and code anchors live in the firmware repo:
+
+> `C:\Users\dufre\Projets\nc-flash-wican-fw\docs\internals\bench-slcan-strand-2026-08.md`
+> and its evergreen companion `docs/internals/returning-to-datalogger.md`
+
+**Read the plan before doing anything.** Do not re-derive the analysis — it is already written up.
+
+## The one-paragraph version
+
+A WiCAN was found stuck in Bench SLCAN mode with datalogging dead (firmware issue #92). This app
+is the only thing that ever writes `protocol: slcan` to a device: `connect_ecu()` probes the
+firmware's always-on coexistence port 35001 with a **1500 ms** timeout, and on **any** probe
+failure — including a brief network hiccup — falls back to the legacy path, which persists
+`slcan` and restores the original only on a clean disconnect or app exit. A session killed in
+between strands the device.
+
+**Status: hypothesis, not proven.** The fallback is real and fired here once — `~/.nc-flash/nc-flash.log`,
+2026-07-12 12:57:20, `WiCAN dedicated port answered rev=None (< NCFRv6); legacy reboot path` — but
+no log covers the 2026-08-11 incident, so the cause of #92 is unattributed.
+
+## Suspected defects in this repo
+
+1. `_try_open_coexist_port()` — ANY probe failure silently downgrades a coexist-capable device to
+   the mode-switching path. A hiccup and a genuinely old firmware are treated identically.
+2. `_restore_wican_protocol()` and `WiCANConfigurator.slcan_session()` — the breadcrumb delete sits
+   in a `finally`, so a **failed** restore destroys the only record of the original mode.
+3. No start-up sweep: `read_recovery()` is consulted only when a new session connects, so a device
+   stranded by a crash stays stranded if the app is never pointed at it again.
+4. The breadcrumb lives in the OS temp directory keyed by IP (`_host_keyed_temp_path()`), so a
+   cleanup or a DHCP address change orphans it.
+
+## Next step — Stage 1, no hardware needed
+
+Three tests, each asserting the **desired** behaviour so they are red today and green after a fix.
+If all three pass unchanged, the hypothesis is wrong and the investigation stops.
+
+1. Probe raises or times out → it must **not** silently switch the device's mode.
+2. `restore()` raises → the breadcrumb file must **still exist**.
+3. Breadcrumb present at start-up with no connect → recovery must run.
+
+Run them with `venv-windows\Scripts\python.exe -m pytest` (the PATH python has no PySide6).
+
+## Do not
+
+- Do not "fix" anything before the three tests exist and are seen red — that is the whole point of
+  the exercise, per the request that a fix be confirmed by replaying the failure.
+- Do not run the bench reproduction (Stage 2 in the plan) casually: it deliberately strands the
+  test device, and its teardown must restore the mode.

--- a/main.py
+++ b/main.py
@@ -2575,6 +2575,14 @@ def main():
         logger.info(f"Opening file from command line: {file_arg}")
         QTimer.singleShot(0, lambda: window._open_rom_file(file_arg))
 
+    # Put back any WiCAN adapter an earlier run left in bench (slcan) mode (#92).
+    # A read-only scan on a worker thread, then ONE dialog before anything is
+    # rebooted. Kept on `window` so its threads outlive this function.
+    from src.ui.wican_strand_recovery import WiCANStrandRecovery
+
+    window._wican_strand_recovery = WiCANStrandRecovery(window)
+    QTimer.singleShot(1500, window._wican_strand_recovery.start)
+
     logger.info("Application window displayed")
     exit_code = app.exec()
     logger.info(f"Application exiting with code {exit_code}")

--- a/pytest.ini
+++ b/pytest.ini
@@ -26,12 +26,15 @@ addopts =
     # Warnings
     -W error::DeprecationWarning
     -W error::PendingDeprecationWarning
+    # Bench tests use real sockets; opt in with '-m bench'.
+    -m "not bench"
 
 # Markers for categorizing tests
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     integration: marks tests as integration tests
     unit: marks tests as unit tests
+    bench: real-socket/real-hardware checks, deselected by default (run with '-m bench')
 
 # Coverage options
 [coverage:run]

--- a/src/ecu/exceptions.py
+++ b/src/ecu/exceptions.py
@@ -41,6 +41,22 @@ class J2534ConnectionError(J2534Error):
     pass
 
 
+class CoexistProbeInconclusive(ECUError):
+    """Raised when we cannot tell whether the adapter supports no-reboot flashing.
+
+    The capability probe on the dedicated SLCAN port failed in a way that proves
+    nothing — a timeout, a reset, an unexpected error — on a device that is
+    otherwise reachable. The old behaviour was to assume old firmware and reboot
+    the adapter into bench (slcan) mode, which stops the datalogger and, if the
+    session then died, left the device stranded that way (#92).
+
+    A refused TCP connect is NOT this: nothing listening on the port is real
+    evidence of pre-coexistence firmware, and that still takes the legacy path.
+    """
+
+    pass
+
+
 # --- UDS Protocol Errors ---
 
 

--- a/src/ecu/session.py
+++ b/src/ecu/session.py
@@ -22,6 +22,7 @@ Two adapters share this one seam (the rest of the app is transport-agnostic):
 """
 
 import logging
+import time
 from enum import Enum
 from typing import Optional
 
@@ -30,6 +31,47 @@ from PySide6.QtCore import QObject, Signal
 from .constants import DEFAULT_J2534_DLL
 
 logger = logging.getLogger(__name__)
+
+#: Longer window for the ONE version-ping retry when the coexistence port
+#: accepted the connection but stayed silent. A busy device or a lossy WiFi link
+#: can eat the first window; a retry is far cheaper than wrongly concluding "old
+#: firmware" and rebooting the adapter out of its datalogging mode (#92).
+_COEXIST_PROBE_RETRY_MS = 3000
+
+
+class ProbeVerdict(Enum):
+    """What the coexistence-port probe actually established.
+
+    The distinction that matters is CONCLUSIVE vs not: only conclusive evidence
+    of pre-coexistence firmware may authorise writing the device's stored mode.
+    """
+
+    #: Coexistence firmware confirmed; use the dedicated port, no reboot.
+    COEXIST = "coexist"
+    #: Conclusively pre-coexistence: the port was refused, or a real NCFRv
+    #: marker came back below the threshold. The legacy mode write is correct.
+    OLD_FIRMWARE = "old_firmware"
+    #: Proved nothing (timeout, reset, silence, unexpected error). Must NOT
+    #: authorise a mode write.
+    INCONCLUSIVE = "inconclusive"
+
+
+def _is_connection_refused(exc: BaseException) -> bool:
+    """True when ``exc`` was ultimately caused by a refused TCP connect.
+
+    The transport wraps socket errors (``raise WiCANError(...) from exc``), so
+    the real cause sits on ``__cause__``/``__context__`` rather than in the
+    message. Matching on the exception type is reliable on both Windows
+    (WSAECONNREFUSED maps to ConnectionRefusedError) and POSIX; matching on the
+    text would not be.
+    """
+    seen = set()
+    while exc is not None and id(exc) not in seen:
+        seen.add(id(exc))
+        if isinstance(exc, ConnectionRefusedError):
+            return True
+        exc = exc.__cause__ or exc.__context__
+    return False
 
 
 class ECUSessionState(Enum):
@@ -113,6 +155,16 @@ class ECUSession(QObject):
     @property
     def is_connected(self) -> bool:
         return self._state in (ECUSessionState.CONNECTED, ECUSessionState.BUSY)
+
+    @property
+    def wican_host(self):
+        """Address of the WiCAN adapter this session drives (``None`` for J2534).
+
+        Public so callers can tell whether a given adapter is already in use --
+        the start-up strand sweep needs it to avoid rebooting a device this app
+        is talking to.
+        """
+        return self._wican_host if self._adapter_kind == "wican" else None
 
     @property
     def device(self):
@@ -223,7 +275,7 @@ class ECUSession(QObject):
         # port open, so flashing needs neither the protocol-switch reboot nor the
         # WiCANConfigurator. Probe for it first; ANY failure falls back below.
         if self._wican_auto_config and not self._slcan_switched:
-            coexist = self._try_open_coexist_port()
+            coexist, verdict = self._try_open_coexist_port()
             if coexist is not None:
                 self._transport = coexist
                 # Reserve the bus for the WHOLE session BEFORE the first UDS frame.
@@ -250,8 +302,14 @@ class ECUSession(QObject):
                 return
             # Not coexistence firmware — switch the adapter into SLCAN mode ONCE
             # per session (a ~6 s reboot). Restore only on a real disconnect.
-            self.progress.emit("Switching adapter to SLCAN (~6 s reboot)…")
             self._configurator = WiCANConfigurator(self._wican_host)
+            if verdict is ProbeVerdict.INCONCLUSIVE:
+                # The probe proved nothing. Writing the stored mode from here is
+                # what strands devices (#92), so establish the right to do it or
+                # abort — this raises unless the device is demonstrably old, or
+                # is already in slcan (where the legacy path writes nothing).
+                self._guard_inconclusive_probe(self._configurator)
+            self.progress.emit("Switching adapter to SLCAN (~6 s reboot)…")
             self._slcan_prev_protocol = self._enter_slcan_durable(self._configurator)
             self._slcan_switched = True
 
@@ -269,17 +327,28 @@ class ECUSession(QObject):
         )
 
     def _try_open_coexist_port(self):
-        """Probe for no-reboot coexistence firmware; return an OPEN transport on
-        its dedicated SLCAN port, or ``None`` to fall back to the reboot path.
+        """Probe for no-reboot coexistence firmware and report WHY it decided.
 
         A coexistence build (firmware rev ``>= COEXIST_MIN_FW_REV``) keeps an
         always-on dedicated SLCAN TCP port that routes through the
         protocol-agnostic fast-read/write codecs, so the host can flash without
         the ~6 s protocol-switch reboot and without the ``WiCANConfigurator``.
-        Detection is a ``version_ping`` over that port with a short connect
-        timeout. ANY failure — old firmware refusing the port, no ``NCFRv``
-        marker, a network hiccup — returns ``None`` so the caller takes the
-        proven legacy path. Strictly non-breaking: the probe never raises.
+
+        This used to collapse EVERY failure into "old firmware", which is only
+        true for some of them. Writing the device's stored mode is a reboot that
+        stops the datalogger, so it needs real evidence, not a shrug (#92):
+
+          * ``OLD_FIRMWARE`` — the TCP connect was REFUSED (nothing is bound to
+            the port; only coexistence firmware ever binds it), or a genuine
+            ``NCFRv`` marker below the threshold came back. Conclusive.
+          * ``COEXIST`` — a marker at/above the threshold. Transport handed back
+            OPEN.
+          * ``INCONCLUSIVE`` — a timeout, a reset, a silent port, an unexpected
+            error. Proves nothing, so it must NOT authorise a mode write.
+
+        Still never raises: it reports a verdict and lets the caller set policy.
+
+        :returns: ``(open_transport_or_None, ProbeVerdict)``
         """
         from .transport import create_ecu_transport
         from .wican_sd_flash import _parse_fw_rev  # reuse the NCFRv<rev> parser
@@ -289,42 +358,202 @@ class ECUSession(QObject):
             COEXIST_PROBE_TIMEOUT_MS,
         )
 
-        probe = None
-        try:
-            probe = create_ecu_transport(
+        def _open(timeout_ms):
+            transport = create_ecu_transport(
                 {
                     "kind": "wican",
                     "host": self._wican_host,
                     "port": WICAN_DEDICATED_SLCAN_PORT,
-                    "connect_timeout_ms": COEXIST_PROBE_TIMEOUT_MS,
+                    "connect_timeout_ms": timeout_ms,
                 }
             )
-            probe.open()
-            rev = _parse_fw_rev(probe.version_ping(window_ms=COEXIST_PROBE_TIMEOUT_MS))
+            try:
+                transport.open()
+            except Exception:
+                # Close here or the half-open socket leaks: the caller only ever
+                # sees the exception, never this transport, so this is the only
+                # place that can clean it up. Matters doubly now that a failed
+                # connect may be retried.
+                try:
+                    transport.close()
+                except Exception:
+                    pass
+                raise
+            return transport
+
+        probe = None
+        verdict = ProbeVerdict.INCONCLUSIVE
+        t0 = time.monotonic()
+        connected_at = None
+        retry_note = None
+        try:
+            try:
+                probe = _open(COEXIST_PROBE_TIMEOUT_MS)
+            except Exception as first:
+                if _is_connection_refused(first):
+                    raise
+                retry_at = time.monotonic()
+                # A timed-out connect and a REFUSED one are the same event seen
+                # through too short a window: measured on Windows, the RST for a
+                # closed port takes ~2 s to surface, while the probe budget is
+                # 1.5 s -- so a genuinely pre-coexistence device looks like a
+                # network problem and would be wrongly refused. Retry once, long
+                # enough for a refusal to land, purely to tell the two apart.
+                # Only failing paths pay this; a healthy port connects in ~20 ms.
+                try:
+                    probe = _open(_COEXIST_PROBE_RETRY_MS)
+                except Exception as second:
+                    retry_note = (
+                        f"attempt 1 unresolved in {COEXIST_PROBE_TIMEOUT_MS} ms; "
+                        f"confirming retry -> "
+                        f"{'refused' if _is_connection_refused(second) else 'still unresolved'}"
+                        f" in {(time.monotonic() - retry_at) * 1000:.0f} ms"
+                    )
+                    raise
+                retry_note = (
+                    f"attempt 1 unresolved in {COEXIST_PROBE_TIMEOUT_MS} ms; "
+                    f"confirming retry -> connected in "
+                    f"{(time.monotonic() - retry_at) * 1000:.0f} ms"
+                )
+            connected_at = time.monotonic()
+            marker = probe.version_ping(window_ms=COEXIST_PROBE_TIMEOUT_MS)
+            if marker is None:
+                # The port ACCEPTED us and then said nothing. Only the
+                # coexistence listener binds this port, so silence here is far
+                # more likely to be a slow link or a busy device than old
+                # firmware. Give it one longer window before giving up.
+                logger.info(
+                    "WiCAN dedicated port accepted but stayed silent; retrying "
+                    "the version ping with a longer window"
+                )
+                marker = probe.version_ping(window_ms=_COEXIST_PROBE_RETRY_MS)
+            rev = _parse_fw_rev(marker)
             if rev is not None and rev >= COEXIST_MIN_FW_REV:
+                verdict = ProbeVerdict.COEXIST
                 self.progress.emit("No-reboot coexistence firmware detected…")
                 logger.info(
                     "WiCAN coexistence firmware NCFRv%s on dedicated port %s",
                     rev,
                     WICAN_DEDICATED_SLCAN_PORT,
                 )
-                return probe  # hand the OPEN transport to the caller
-            logger.info(
-                "WiCAN dedicated port answered rev=%s (< NCFRv%s); legacy reboot path",
-                rev,
-                COEXIST_MIN_FW_REV,
-            )
+            elif rev is not None:
+                verdict = ProbeVerdict.OLD_FIRMWARE
+                logger.info(
+                    "WiCAN dedicated port answered NCFRv%s (< NCFRv%s); "
+                    "legacy reboot path",
+                    rev,
+                    COEXIST_MIN_FW_REV,
+                )
+            else:
+                logger.warning(
+                    "WiCAN dedicated port %s accepted the connection but never "
+                    "sent its version marker; capability UNKNOWN (refusing to "
+                    "assume old firmware)",
+                    WICAN_DEDICATED_SLCAN_PORT,
+                )
         except Exception as exc:
-            logger.debug(
-                "WiCAN coexist-port probe failed (%s); legacy reboot path", exc
+            if _is_connection_refused(exc):
+                verdict = ProbeVerdict.OLD_FIRMWARE
+                logger.info(
+                    "WiCAN dedicated port %s refused the connection; "
+                    "pre-coexistence firmware, legacy reboot path",
+                    WICAN_DEDICATED_SLCAN_PORT,
+                )
+            else:
+                logger.warning(
+                    "WiCAN coexist-port probe failed inconclusively (%s); "
+                    "capability UNKNOWN",
+                    exc,
+                )
+        finally:
+            now = time.monotonic()
+            # One line per probe carrying the verdict and where the time went, so
+            # a field report is attributable to connect / ping instead of guessed
+            # at. A probe that needed the confirming retry is logged at WARNING
+            # with the measured refusal latency: that number is the only evidence
+            # that would justify re-tuning _COEXIST_PROBE_RETRY_MS, and it varies
+            # with the OS TCP retransmission settings, not machine speed.
+            logger.log(
+                logging.WARNING if retry_note else logging.INFO,
+                "coexist probe: verdict=%s connect=%.2fs ping=%.2fs total=%.2fs%s",
+                verdict.value,
+                (connected_at - t0) if connected_at else (now - t0),
+                (now - connected_at) if connected_at else 0.0,
+                now - t0,
+                f" [{retry_note}]" if retry_note else "",
             )
-        # Not coexistence (or probe failed): close any half-open probe, fall back.
+
+        if verdict is ProbeVerdict.COEXIST:
+            return probe, verdict  # hand the OPEN transport to the caller
         if probe is not None:
             try:
                 probe.close()
             except Exception:
                 pass
-        return None
+        return None, verdict
+
+    def _guard_inconclusive_probe(self, configurator):
+        """Establish the right to write the stored mode, or refuse (#92).
+
+        Reached only when the capability probe proved nothing. Rebooting the
+        adapter into bench mode stops the datalogger, and if the session then
+        dies the device stays that way — so this path needs evidence, not a
+        guess. Order of preference:
+
+          1. ``/host_caps`` — a small, secret-free capability reply. A rev at or
+             above the threshold means coexistence firmware IS present and its
+             port is simply not answering: there is nothing to connect to and no
+             right to write. Below the threshold is conclusive old firmware.
+          2. No ``/host_caps`` (every build in the field before it shipped) —
+             fall back to the stored protocol. Already ``slcan`` means the
+             legacy path performs NO write, so it is safe to continue; that also
+             keeps a device this tool previously stranded reachable.
+
+        :raises CoexistProbeInconclusive: when no evidence justifies the write.
+        """
+        from .exceptions import CoexistProbeInconclusive
+        from .constants import COEXIST_MIN_FW_REV, WICAN_DEDICATED_SLCAN_PORT
+
+        caps = configurator.host_caps()
+        rev = (caps or {}).get("ncfr_rev")
+        if isinstance(rev, int):
+            if rev >= COEXIST_MIN_FW_REV:
+                raise CoexistProbeInconclusive(
+                    f"This adapter reports no-reboot firmware (NCFRv{rev}), but "
+                    f"its port {WICAN_DEDICATED_SLCAN_PORT} did not answer. "
+                    "Refusing to reboot it into bench mode — check the Wi-Fi "
+                    "link and try again."
+                )
+            logger.info(
+                "/host_caps reports NCFRv%s (< NCFRv%s); legacy mode write is "
+                "justified",
+                rev,
+                COEXIST_MIN_FW_REV,
+            )
+            return
+
+        try:
+            current = configurator.current_protocol()
+        except Exception as exc:
+            raise CoexistProbeInconclusive(
+                "Could not confirm whether this adapter supports no-reboot "
+                f"flashing, and it did not answer over HTTP either ({exc}). "
+                "Refusing to change its mode."
+            ) from exc
+
+        if current == "slcan":
+            logger.info(
+                "probe inconclusive but the adapter is already in slcan; "
+                "continuing on the legacy path (no mode write will occur)"
+            )
+            return
+
+        raise CoexistProbeInconclusive(
+            f"Could not confirm whether this adapter supports no-reboot "
+            f"flashing: port {WICAN_DEDICATED_SLCAN_PORT} did not answer, "
+            f"though the device is reachable and reports {current!r}. Refusing "
+            "to reboot it into bench mode — check the Wi-Fi link and try again."
+        )
 
     @staticmethod
     def _enter_slcan_durable(configurator) -> str:
@@ -500,12 +729,24 @@ class ECUSession(QObject):
                 self.progress.emit("Restoring adapter protocol (~6 s reboot)…")
                 self._configurator.restore(prev)
         except Exception as exc:
-            logger.warning("WiCAN protocol restore failed: %s", exc)
-        finally:
-            try:
-                self._configurator.clear_recovery()
-            except Exception:
-                pass
-            self._slcan_switched = False
-            self._slcan_prev_protocol = None
-            self._configurator = None
+            # KEEP the breadcrumb AND the switch state (#92). The device is still
+            # in slcan and the sidecar is the only record of the user's real
+            # mode; clearing it here strands the device permanently. Holding the
+            # state also leaves cleanup() -- which runs at app exit and on
+            # session replacement -- a free second attempt, and a reconnect still
+            # works because the `not _slcan_switched` guard skips the re-switch.
+            # If the restore only failed its verify while the write landed, the
+            # retry's set_protocol no-ops and cleanly clears the sidecar.
+            logger.warning(
+                "WiCAN protocol restore failed: %s -- breadcrumb KEPT so a later "
+                "run can un-strand the device",
+                exc,
+            )
+            return
+        try:
+            self._configurator.clear_recovery()
+        except Exception:
+            pass
+        self._slcan_switched = False
+        self._slcan_prev_protocol = None
+        self._configurator = None

--- a/src/ecu/wican_config.py
+++ b/src/ecu/wican_config.py
@@ -1060,8 +1060,9 @@ def recover_stranded_protocols(
                 os.unlink(path)
             except OSError:
                 pass
-            records.append({"host": host, "previous_protocol": previous,
-                            "action": "invalid"})
+            records.append(
+                {"host": host, "previous_protocol": previous, "action": "invalid"}
+            )
             continue
 
         record = {"host": host, "previous_protocol": previous, "action": None}
@@ -1080,7 +1081,8 @@ def recover_stranded_protocols(
         if current != SLCAN:
             logger.info(
                 "sweep: %s is on %r, not stranded; dropping stale sidecar",
-                host, current,
+                host,
+                current,
             )
             cfg.clear_recovery()
             record["action"] = "stale"

--- a/src/ecu/wican_config.py
+++ b/src/ecu/wican_config.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import atexit
 import contextlib
+import glob
 import json
 import logging
 import os
@@ -98,17 +99,56 @@ def get_top_level_protocol(raw: str) -> str:
     return matches[0]
 
 
-def _host_keyed_temp_path(host: object, prefix: str) -> str:
-    """Path of a host-keyed JSON sidecar in the OS temp dir.
+#: Sidecar home, under the user profile rather than the OS temp dir. A temp
+#: clean would otherwise silently destroy the only record of a stranded device's
+#: real mode (#92). The app already creates this directory for its logs.
+_SIDECAR_DIRNAME = ".nc-flash"
 
-    Keyed by ``host`` (sanitized to a filesystem-safe token) so concurrent runs
-    against different devices never clobber each other, and stable across runs so
-    a NEXT run can detect and recover a stranded device. ``prefix`` namespaces the
-    file (``wican_recovery`` for the protocol sidecar vs ``wican_datalog`` for the
-    datalog-pause breadcrumb) so the two never collide.
+
+def _sidecar_dir() -> str:
+    """Directory holding the host-keyed sidecars, created on demand.
+
+    Degrades to the OS temp dir if the home directory cannot be used, so a
+    locked-down machine behaves as it did before rather than failing outright.
     """
-    safe_host = re.sub(r"[^A-Za-z0-9]", "_", str(host))
-    return os.path.join(tempfile.gettempdir(), f"{prefix}_{safe_host}.json")
+    try:
+        path = os.path.join(os.path.expanduser("~"), _SIDECAR_DIRNAME)
+        os.makedirs(path, exist_ok=True)
+        return path
+    except OSError:  # pragma: no cover - unwritable home
+        return tempfile.gettempdir()
+
+
+def _sanitize_host(host: object) -> str:
+    """Host reduced to a filesystem-safe token (``192.168.1.9`` -> ``192_168_1_9``)."""
+    return re.sub(r"[^A-Za-z0-9]", "_", str(host))
+
+
+def _host_keyed_temp_path(host: object, prefix: str) -> str:
+    """Path of a host-keyed JSON sidecar.
+
+    Keyed by ``host`` so concurrent runs against different devices never clobber
+    each other, and stable across runs so a NEXT run can detect and recover a
+    stranded device. ``prefix`` namespaces the file (``wican_recovery`` for the
+    protocol sidecar vs ``wican_datalog`` for the datalog-pause breadcrumb) so
+    the two never collide.
+    """
+    return os.path.join(_sidecar_dir(), f"{prefix}_{_sanitize_host(host)}.json")
+
+
+def _legacy_host_keyed_temp_path(host: object, prefix: str) -> str:
+    """The pre-#92 OS-temp location, still read once so upgrades keep working."""
+    return os.path.join(tempfile.gettempdir(), f"{prefix}_{_sanitize_host(host)}.json")
+
+
+def _read_sidecar_json(path: str):
+    """Load a sidecar, or ``None`` if missing/unreadable/not JSON. Never raises."""
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.loads(fh.read())
+    except (OSError, ValueError, TypeError):
+        return None
+    return data if isinstance(data, dict) else None
 
 
 def set_top_level_protocol(raw: str, value: str) -> str:
@@ -193,25 +233,54 @@ class WiCANConfigurator:
         file whose ``host`` matches ours, so a stale sidecar from a different
         device is never applied here.
         """
-        path = self.recovery_path
-        try:
-            with open(path, "r", encoding="utf-8") as fh:
-                data = json.loads(fh.read())
-        except (OSError, ValueError, TypeError):
-            return None
-        if not isinstance(data, dict):
+        data = _read_sidecar_json(self.recovery_path)
+        if data is None:
+            data = self._migrate_legacy_recovery()
+        if data is None:
             return None
         if data.get("host") != self.host:
             return None
         prev = data.get("previous_protocol")
         return prev if isinstance(prev, str) else None
 
+    def _migrate_legacy_recovery(self):
+        """Adopt a sidecar left in the OS temp dir by a pre-#92 build.
+
+        Read once, rewritten to the new home, and the old copy removed. Without
+        this an upgrade would look like "no breadcrumb" and a device stranded by
+        the previous version could never be recovered automatically.
+        """
+        legacy = _legacy_host_keyed_temp_path(self.host, "wican_recovery")
+        if legacy == self.recovery_path:
+            return None
+        data = _read_sidecar_json(legacy)
+        if data is None:
+            return None
+        prev = data.get("previous_protocol")
+        if data.get("host") == self.host and isinstance(prev, str):
+            try:
+                self._write_recovery(prev)
+                os.unlink(legacy)
+                logger.info("migrated WiCAN recovery sidecar from %s", legacy)
+            except OSError:  # keep the legacy copy if the move failed
+                pass
+        return data
+
     def clear_recovery(self) -> None:
-        """Best-effort delete of the recovery sidecar (ignore if missing)."""
-        try:
-            os.unlink(self.recovery_path)
-        except OSError:
-            pass
+        """Best-effort delete of the recovery sidecar (ignore if missing).
+
+        Also clears any pre-#92 copy in the OS temp dir, so a restore performed
+        by this build cannot leave a stale breadcrumb that a later sweep would
+        act on.
+        """
+        for path in (
+            self.recovery_path,
+            _legacy_host_keyed_temp_path(self.host, "wican_recovery"),
+        ):
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
 
     def write_recovery(self, protocol: str) -> None:
         """Public: persist the TRUE original protocol to the recovery sidecar.
@@ -254,6 +323,41 @@ class WiCANConfigurator:
                 f"GET /load_config returned HTTP {status} from {self.host}"
             )
         return body.decode("utf-8", errors="replace")
+
+    def host_caps(self, timeout_s: Optional[float] = None) -> Optional[dict]:
+        """``GET /host_caps`` -> ``{"ncfr_rev": int, "protocol": str}``, or ``None``.
+
+        A small, constant, secret-free reply that tells a host tool what this
+        boot is and can do. Preferred over ``/load_config`` for capability and
+        "is this device stranded?" checks, because the config blob carries the
+        user's WiFi passwords in cleartext and is expensive for the device to
+        assemble while it is busy.
+
+        Returns ``None`` — never raises — when the endpoint is absent (every
+        build in the field before it shipped answers 404), unreachable, or
+        unparseable. Callers MUST treat ``None`` as "unknown, fall back", never
+        as evidence of old firmware.
+
+        Note ``protocol`` is the STORED mode, not the running one: a restore
+        targets what was written, and under SmartConnect the two differ.
+        """
+        try:
+            with urllib.request.urlopen(
+                self._url("/host_caps"),
+                timeout=self.timeout_s if timeout_s is None else timeout_s,
+            ) as resp:
+                status = getattr(resp, "status", None) or resp.getcode()
+                body = resp.read()
+        except Exception as exc:
+            logger.debug("GET /host_caps on %s unavailable: %s", self.host, exc)
+            return None
+        if status != 200:
+            return None
+        try:
+            data = json.loads(body.decode("utf-8", errors="replace"))
+        except ValueError:
+            return None
+        return data if isinstance(data, dict) else None
 
     def read_config(self) -> dict:
         """Return the parsed config dict (``json.loads`` of the raw blob).
@@ -334,10 +438,14 @@ class WiCANConfigurator:
             yield true_prev
         finally:
             if true_prev != SLCAN:
-                try:
-                    self.restore(true_prev)
-                finally:
-                    self.clear_recovery()
+                # Clear the sidecar ONLY after the restore actually returned. If
+                # the restore raises, the device is still in slcan and this file
+                # is the only record of the user's real mode -- deleting it here
+                # is what turns a recoverable failure into a PERMANENT strand
+                # (#92; bench-proven: with no sidecar even a clean reconnect
+                # leaves the device in slcan and the tool exits 0).
+                self.restore(true_prev)
+                self.clear_recovery()
 
     def set_protocol(self, protocol: str) -> None:
         """Set the device's top-level protocol to ``protocol`` and verify.
@@ -864,3 +972,148 @@ class WiCANDatalogClient:
             "datalog reconcile: resuming a datalogger left paused by a prior run"
         )
         self.resume()
+
+
+# ---------------------------------------------------------------------------
+# Start-up recovery sweep (#92).
+#
+# Before this, a device left in slcan was only ever un-stranded inside a LATER
+# successful connect to that same host. That is the one thing a user whose
+# logger just stopped working is least likely to do. Bench-proven: with the
+# sidecar gone, even a clean reconnect leaves the device in slcan and the tool
+# exits 0. The sweep runs at app start-up instead, needs no connect, and asks
+# before it reboots anything.
+# ---------------------------------------------------------------------------
+
+
+def _stored_protocol(cfg: "WiCANConfigurator") -> Optional[str]:
+    """The device's STORED protocol, or ``None`` if it cannot be reached.
+
+    Prefers ``/host_caps`` — small, constant, and free of the cleartext WiFi
+    passwords that ``/load_config`` carries — and falls back to the config blob
+    for firmware that predates that endpoint.
+    """
+    caps = cfg.host_caps()
+    if caps is not None:
+        proto = caps.get("protocol")
+        if isinstance(proto, str):
+            return proto
+    try:
+        return cfg.current_protocol()
+    except WiCANConfigError as exc:
+        logger.info("sweep: %s is unreachable (%s)", cfg.host, exc)
+        return None
+
+
+def _sweep_sidecar_paths() -> list:
+    """Every protocol sidecar on this machine, new home first then the old one."""
+    seen, paths = set(), []
+    for directory in (_sidecar_dir(), tempfile.gettempdir()):
+        for path in sorted(glob.glob(os.path.join(directory, "wican_recovery_*.json"))):
+            key = os.path.normcase(os.path.abspath(path))
+            if key not in seen:
+                seen.add(key)
+                paths.append(path)
+    return paths
+
+
+def recover_stranded_protocols(
+    confirm=None,
+    http_port: int = 80,
+    should_skip=None,
+    timeout_s: float = 4.0,
+) -> list:
+    """Find devices this machine left in ``slcan`` and put them back.
+
+    Headless and never raises, so it is safe to call from app start-up. It walks
+    the protocol sidecars, and for each one decides:
+
+      * device unreachable -> keep the sidecar, try again next launch
+      * stored mode is not ``slcan`` -> nothing to undo; drop the stale sidecar
+        WITHOUT touching the device
+      * a flash or a host bus-claim is live -> **leave it alone**. Rebooting a
+        device mid-flash can leave the car's ECU half-written, and the owner of
+        that session (possibly on another machine) will restore it. This mirrors
+        :meth:`WiCANDatalogClient.reconcile`'s refusal and is the brick guard.
+      * otherwise ask ``confirm(host, previous_protocol)`` if given, then restore
+
+    :param confirm: optional ``(host, previous_protocol) -> bool``. Returning
+        ``False`` keeps the sidecar and leaves the device alone. Omit it for a
+        fully automatic sweep (tests, headless use).
+    :param should_skip: optional ``(host) -> bool`` so a GUI can exclude a host
+        it already holds a live session to.
+    :param http_port: device HTTP port; tests point this at a loopback mock.
+    :returns: one record per sidecar — ``{"host", "previous_protocol", "action"}``
+        where action is one of ``restored``, ``stale``, ``unreachable``,
+        ``busy``, ``declined``, ``failed``, ``skipped``, ``invalid``.
+    """
+    records = []
+    for path in _sweep_sidecar_paths():
+        data = _read_sidecar_json(path)
+        host = (data or {}).get("host")
+        previous = (data or {}).get("previous_protocol")
+        if not isinstance(host, str) or not isinstance(previous, str):
+            # Unusable sidecar: it names no host or no mode, so it can never
+            # drive a restore. Drop it rather than re-reading it every launch.
+            logger.info("sweep: discarding unusable sidecar %s", path)
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+            records.append({"host": host, "previous_protocol": previous,
+                            "action": "invalid"})
+            continue
+
+        record = {"host": host, "previous_protocol": previous, "action": None}
+        records.append(record)
+
+        if should_skip is not None and should_skip(host):
+            logger.info("sweep: %s has a live session; skipping", host)
+            record["action"] = "skipped"
+            continue
+
+        cfg = WiCANConfigurator(host, http_port=http_port, timeout_s=timeout_s)
+        current = _stored_protocol(cfg)
+        if current is None:
+            record["action"] = "unreachable"
+            continue
+        if current != SLCAN:
+            logger.info(
+                "sweep: %s is on %r, not stranded; dropping stale sidecar",
+                host, current,
+            )
+            cfg.clear_recovery()
+            record["action"] = "stale"
+            continue
+
+        state = WiCANDatalogClient(host, http_port=http_port).get_state()
+        if state is not None and (
+            state.get("flash_active") or state.get("host_bus_claimed")
+        ):
+            # A programming session owns this device -- this instance or another
+            # machine. Rebooting it now is a brick risk for the car's ECU.
+            logger.warning(
+                "sweep: %s is stranded but a flash/claim is ACTIVE -- leaving it "
+                "alone; its owner or the firmware reaper will release it",
+                host,
+            )
+            record["action"] = "busy"
+            continue
+
+        if confirm is not None and not confirm(host, previous):
+            logger.info("sweep: user declined restoring %s", host)
+            record["action"] = "declined"
+            continue
+
+        try:
+            logger.info("sweep: restoring %s from slcan to %r", host, previous)
+            cfg.restore(previous)
+        except Exception as exc:
+            # Keep the sidecar: the device is still stranded and this file is
+            # the only record of the real mode.
+            logger.warning("sweep: restoring %s failed (%s); sidecar kept", host, exc)
+            record["action"] = "failed"
+            continue
+        cfg.clear_recovery()
+        record["action"] = "restored"
+    return records

--- a/src/ui/settings_dialog.py
+++ b/src/ui/settings_dialog.py
@@ -4,6 +4,7 @@ Settings Dialog
 Configuration window with tree navigation and search.
 """
 
+import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -37,6 +38,8 @@ from PySide6.QtWidgets import (
 
 from ..utils.settings import get_settings
 from ..utils.colormap import reload_colormap
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Settings Registry
@@ -1129,7 +1132,19 @@ class SettingsDialog(QDialog):
         try:
             if auto_config:
                 configurator = WiCANConfigurator(host)
-                prev_protocol = configurator.switch_to_slcan()
+                # Write the crash-recovery breadcrumb BEFORE switching, the same
+                # way a real session does. The bare switch_to_slcan() this
+                # replaces left NO record at all, so a crash during the ~6 s
+                # reboot -- or the silently-swallowed restore below -- stranded
+                # the device in bench mode with nothing able to find it, not even
+                # the start-up sweep (#92).
+                recorded = configurator.read_recovery()
+                current = configurator.current_protocol()
+                prev_protocol = recorded if recorded is not None else current
+                if prev_protocol != "slcan":
+                    configurator.write_recovery(prev_protocol)
+                if current != "slcan":
+                    configurator.set_protocol("slcan")
             transport = create_ecu_transport(
                 {"kind": "wican", "host": host, "port": port}
             )
@@ -1170,8 +1185,19 @@ class SettingsDialog(QDialog):
             if configurator is not None and prev_protocol and prev_protocol != "slcan":
                 try:
                     configurator.restore(prev_protocol)
-                except Exception:
-                    pass
+                except Exception as exc:
+                    # KEEP the breadcrumb (#92): the device is still in bench
+                    # mode and this is the only record of the user's real one.
+                    # The next launch's sweep will offer to put it back.
+                    logger.warning(
+                        "WiCAN Test Connection: restoring %s to %r failed (%s); "
+                        "breadcrumb kept so start-up can recover it",
+                        host,
+                        prev_protocol,
+                        exc,
+                    )
+                else:
+                    configurator.clear_recovery()
 
     def _scan_wican_devices(self, host_edit):
         """Discover WiCAN adapters over mDNS (off-thread) and let the user pick one.

--- a/src/ui/wican_strand_recovery.py
+++ b/src/ui/wican_strand_recovery.py
@@ -1,0 +1,194 @@
+"""Start-up recovery for a WiCAN adapter left in bench (slcan) mode (#92).
+
+Flashing over WiFi on pre-coexistence firmware means rebooting the adapter into
+``slcan``, and putting it back afterwards. If that session dies first -- a crash,
+a force-quit, a closed laptop -- the adapter stays in bench mode: it stops
+datalogging, and nothing puts it right. Until now the only cure was reconnecting
+to that exact device, which is the last thing someone whose logger just died
+tends to do.
+
+This runs one scan at start-up instead. Two phases, both driven by the same
+:func:`~src.ecu.wican_config.recover_stranded_protocols` used by the tests:
+
+  1. **Scan (read-only).** Declines every restore, so it only reports which
+     devices are genuinely stranded -- reachable, stored mode is ``slcan``, and
+     no flash or host bus-claim in progress. Nothing is written.
+  2. **Restore (after the user agrees).** Re-runs the sweep, approving only the
+     hosts the user accepted.
+
+Both phases run on a worker thread: the scan does network I/O and a restore
+blocks for the device's reboot, neither of which may sit on the UI thread.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from PySide6.QtCore import QObject, QThread, Signal
+
+logger = logging.getLogger(__name__)
+
+
+class _StrandScanWorker(QObject):
+    """Read-only scan for stranded adapters (see phase 1 above)."""
+
+    finished = Signal(list)  # [{"host", "previous_protocol", ...}, ...]
+
+    def __init__(self, busy_hosts=frozenset()):
+        super().__init__()
+        self._busy_hosts = busy_hosts
+
+    def run(self):
+        candidates = []
+        try:
+            from src.ecu.wican_config import recover_stranded_protocols
+
+            # confirm=False everywhere: this pass may not write anything. The
+            # sweep still does all the safety checks, so a host that comes back
+            # "declined" is one that IS stranded and IS safe to restore.
+            for record in recover_stranded_protocols(
+                confirm=lambda host, prev: False,
+                should_skip=self._busy_hosts.__contains__,
+            ):
+                if record.get("action") == "declined":
+                    candidates.append(record)
+        except Exception:  # never let start-up break on this
+            logger.exception("WiCAN strand scan failed")
+        self.finished.emit(candidates)
+
+
+class _StrandRestoreWorker(QObject):
+    """Restore the approved hosts (phase 2)."""
+
+    finished = Signal(list)
+
+    def __init__(self, approved, busy_hosts=frozenset()):
+        super().__init__()
+        self._approved = set(approved)
+        self._busy_hosts = busy_hosts
+
+    def run(self):
+        records = []
+        try:
+            from src.ecu.wican_config import recover_stranded_protocols
+
+            records = recover_stranded_protocols(
+                confirm=lambda host, prev: host in self._approved,
+                should_skip=self._busy_hosts.__contains__,
+            )
+        except Exception:
+            logger.exception("WiCAN strand restore failed")
+        self.finished.emit(records)
+
+
+class WiCANStrandRecovery(QObject):
+    """Owns the start-up scan, its dialog, and the restore that may follow.
+
+    Held by the caller for the life of the app so the worker threads are not
+    garbage collected mid-run.
+    """
+
+    def __init__(self, parent_window):
+        super().__init__(parent_window)
+        self._window = parent_window
+        self._threads = []
+
+    def start(self):
+        """Kick the read-only scan. Returns immediately."""
+        self._run(_StrandScanWorker(self._busy_hosts()), self._on_scan_done)
+
+    def _busy_hosts(self) -> frozenset:
+        """Adapters this app is already using, as a plain frozen set.
+
+        Restoring an adapter we are actively using would reboot it out from
+        under our own session. On coexistence firmware the sweep catches that
+        anyway (our session holds the bus claim, so it reports ``busy``); on
+        older firmware there is no such signal, and this is the only check.
+
+        MUST be called on the UI thread -- it reads window/session state, which
+        the workers may not touch. The workers get this immutable snapshot
+        instead of a callback into live objects. It is taken fresh for each
+        phase, so the dialog sitting unanswered does not stale it.
+
+        Deliberately tolerant: an unexpected window layout yields an empty set
+        rather than disabling recovery; the sweep's flash/claim guard is what
+        actually protects a device mid-flash.
+        """
+        try:
+            ecu_window = getattr(self._window, "ecu_window", None)
+            session = getattr(ecu_window, "_session", None)
+            if session is None or not session.is_connected:
+                return frozenset()
+            host = session.wican_host
+            return frozenset([host]) if host else frozenset()
+        except Exception:
+            logger.debug("could not check for live WiCAN sessions", exc_info=True)
+            return frozenset()
+
+    # -- internals ---------------------------------------------------------
+
+    def _run(self, worker, on_finished):
+        thread = QThread()
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+        worker.finished.connect(on_finished)
+        worker.finished.connect(thread.quit)
+        thread.finished.connect(thread.deleteLater)
+        # Keep both alive; a collected QThread mid-run crashes the app.
+        self._threads.append((thread, worker))
+        thread.start()
+
+    def _on_scan_done(self, candidates):
+        if not candidates:
+            logger.debug("WiCAN strand scan: nothing stranded")
+            return
+
+        from PySide6.QtWidgets import QMessageBox
+
+        hosts = [c["host"] for c in candidates]
+        listed = "\n".join(
+            f"  • {c['host']}  (was {c['previous_protocol']})" for c in candidates
+        )
+        logger.warning("WiCAN strand scan found stranded adapter(s): %s", hosts)
+
+        answer = QMessageBox.question(
+            self._window,
+            "WiCAN adapter left in bench mode",
+            "An earlier session left this adapter in bench (SLCAN) mode, so it "
+            "is not datalogging:\n\n"
+            f"{listed}\n\n"
+            "Put it back now? The adapter will reboot, which takes a few "
+            "seconds.\n\n"
+            "Do NOT do this if another computer is flashing an ECU through it.",
+            QMessageBox.Yes | QMessageBox.No,
+            # Default to No. On pre-coexistence firmware there is no /datalog to
+            # ask, so this Yes is the ONLY thing standing between the sweep and
+            # rebooting a device that might be mid-ECU-write -- which can leave
+            # the car's PCM half-written. An absent-minded Enter must land on
+            # the side that does nothing.
+            QMessageBox.No,
+        )
+        if answer != QMessageBox.Yes:
+            logger.info("User declined WiCAN strand recovery for %s", hosts)
+            return
+        self._run(
+            _StrandRestoreWorker(hosts, self._busy_hosts()), self._on_restore_done
+        )
+
+    def _on_restore_done(self, records):
+        restored = [r["host"] for r in records if r.get("action") == "restored"]
+        failed = [r["host"] for r in records if r.get("action") == "failed"]
+        logger.info("WiCAN strand recovery: restored=%s failed=%s", restored, failed)
+        if not failed:
+            return
+
+        from PySide6.QtWidgets import QMessageBox
+
+        QMessageBox.warning(
+            self._window,
+            "Could not restore the adapter",
+            "The adapter could not be put back into its normal mode:\n\n"
+            + "\n".join(f"  • {h}" for h in failed)
+            + "\n\nIt is still in bench mode and will not datalog. NC Flash will "
+            "try again next time it starts.",
+        )

--- a/tests/bench/slcan_strand_driver.py
+++ b/tests/bench/slcan_strand_driver.py
@@ -24,7 +24,9 @@ import os
 import sys
 
 # Import from the repo root regardless of where this is invoked from.
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 
 #: The proxy's loopback address. Everything the driver touches goes through it,
 #: so the breadcrumb sidecar is keyed to 127_0_0_1 rather than the device IP.
@@ -74,7 +76,9 @@ def main(argv=None) -> int:
             "auto_config": True,
         }
     )
-    session.progress.connect(lambda m: logging.getLogger("driver").info("progress: %s", m))
+    session.progress.connect(
+        lambda m: logging.getLogger("driver").info("progress: %s", m)
+    )
     session.connection_lost.connect(
         lambda m: logging.getLogger("driver").warning("connection_lost: %s", m)
     )

--- a/tests/bench/slcan_strand_driver.py
+++ b/tests/bench/slcan_strand_driver.py
@@ -1,0 +1,94 @@
+"""Drive a single ECUSession connect against the strand proxy (#92 bench repro).
+
+Runs headless in its OWN process so the strand can be produced deterministically
+instead of by racing ``taskkill``. The window between "the mode write landed"
+and "teardown restores it" is only a couple of seconds, so rather than trying to
+kill from outside, ``--strand`` makes the process die from the inside at exactly
+the right instant: ``UDSConnection.tester_present`` is patched to ``os._exit``,
+which is the closest software equivalent of a power cut -- no ``finally``, no
+``atexit``, no Qt teardown, no protocol restore.
+
+Usage (always through the proxy, never straight at the device):
+
+    python tests/bench/slcan_strand_driver.py            # connect and disconnect cleanly
+    python tests/bench/slcan_strand_driver.py --strand   # connect, then die mid-session
+
+Exit codes: 0 clean, 1 killed by --strand (expected), 2 connect failed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+# Import from the repo root regardless of where this is invoked from.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+#: The proxy's loopback address. Everything the driver touches goes through it,
+#: so the breadcrumb sidecar is keyed to 127_0_0_1 rather than the device IP.
+PROXY_HOST = "127.0.0.1"
+PROXY_LEGACY_PORT = 35000
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--strand",
+        action="store_true",
+        help="die inside the session, after any mode write, before any restore",
+    )
+    args = ap.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        stream=sys.stdout,
+    )
+
+    from PySide6.QtWidgets import QApplication
+    from src.ecu.session import ECUSession, ECUSessionState
+
+    app = QApplication.instance() or QApplication([])  # noqa: F841 (Qt needs it alive)
+
+    if args.strand:
+        from src.ecu.protocol import UDSConnection
+
+        def _die(self, *a, **kw):
+            # We are past the protocol switch and inside the live session. This
+            # is where a crash, a force-quit or a yanked power lead would land.
+            logging.getLogger("driver").warning(
+                "STRAND: killing the process mid-session (no restore will run)"
+            )
+            sys.stdout.flush()
+            os._exit(1)
+
+        UDSConnection.tester_present = _die
+
+    session = ECUSession(
+        adapter_config={
+            "kind": "wican",
+            "host": PROXY_HOST,
+            "port": PROXY_LEGACY_PORT,
+            "auto_config": True,
+        }
+    )
+    session.progress.connect(lambda m: logging.getLogger("driver").info("progress: %s", m))
+    session.connection_lost.connect(
+        lambda m: logging.getLogger("driver").warning("connection_lost: %s", m)
+    )
+
+    session.connect_ecu()
+
+    if session.state != ECUSessionState.CONNECTED:
+        logging.getLogger("driver").error("connect failed (state=%s)", session.state)
+        return 2
+
+    logging.getLogger("driver").info("connected; disconnecting cleanly")
+    session.disconnect_ecu()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/bench/slcan_strand_proxy.py
+++ b/tests/bench/slcan_strand_proxy.py
@@ -135,7 +135,9 @@ def _serve(port: int, device_host: str, mode: str, stop: threading.Event) -> Non
 
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--device", required=True, help="real device IP, e.g. 192.168.1.169")
+    ap.add_argument(
+        "--device", required=True, help="real device IP, e.g. 192.168.1.169"
+    )
     ap.add_argument(
         "--mode",
         choices=("stall", "drop", "pass"),

--- a/tests/bench/slcan_strand_proxy.py
+++ b/tests/bench/slcan_strand_proxy.py
@@ -1,0 +1,180 @@
+"""TCP proxy that reproduces the Bench SLCAN strand (#92) on real hardware.
+
+The strand needs the coexistence-port probe to fail on a device that is
+otherwise perfectly reachable. On the bench that never happens by itself --
+measured 5/5 successful probes at ~0.45 s against a 1.5 s budget -- so the
+failure has to be induced.
+
+This proxy sits between NC Flash and the device:
+
+    NC Flash  ->  127.0.0.1:80     ->  device:80      (always forwarded)
+                  127.0.0.1:35000  ->  device:35000   (always forwarded)
+                  127.0.0.1:35001  ->  device:35001   (mode-dependent)
+
+Port 35001 modes:
+
+    stall   accept the connection, then never forward or answer a byte.
+            Reproduces the exact field signature: the SLCAN bring-up tolerates
+            silence, so open() succeeds and the version ping window closes
+            empty -> ``rev=None`` -> the legacy mode-write path.
+    drop    do not listen at all, so the OS answers with a TCP RST. This is the
+            CONCLUSIVE "nothing is bound to 35001" case, i.e. genuine
+            pre-coexistence firmware. Used to prove the fix does not break
+            legacy hardware.
+    pass    forward normally -- the healthy control.
+
+Deliberately dependency-free (stdlib only) so it can run from any shell.
+
+    python tests/bench/slcan_strand_proxy.py --device 192.168.1.169 --mode stall
+
+Ports 80 and 35000 are ALWAYS forwarded, in every mode. That is the whole
+point: the device must look healthy to everything except the capability probe.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import socket
+import sys
+import threading
+
+logger = logging.getLogger("slcan_strand_proxy")
+
+#: Ports forwarded verbatim regardless of mode (HTTP config + legacy SLCAN).
+ALWAYS_FORWARD = (80, 35000)
+#: The coexistence capability port whose behaviour the experiment controls.
+COEXIST_PORT = 35001
+
+
+def _pump(src: socket.socket, dst: socket.socket) -> None:
+    """Copy bytes one way until either end closes. Never raises."""
+    try:
+        while True:
+            chunk = src.recv(65536)
+            if not chunk:
+                break
+            dst.sendall(chunk)
+    except OSError:
+        pass
+    finally:
+        for s in (src, dst):
+            try:
+                s.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+
+
+def _forward(client: socket.socket, device_host: str, port: int) -> None:
+    """Splice one accepted client onto a fresh device connection."""
+    upstream = socket.socket()
+    try:
+        upstream.settimeout(5.0)
+        upstream.connect((device_host, port))
+        upstream.settimeout(None)
+    except OSError as exc:
+        logger.warning("upstream connect to %s:%s failed: %s", device_host, port, exc)
+        client.close()
+        upstream.close()
+        return
+    threading.Thread(target=_pump, args=(client, upstream), daemon=True).start()
+    threading.Thread(target=_pump, args=(upstream, client), daemon=True).start()
+
+
+def _stall(client: socket.socket) -> None:
+    """Accept and hold the connection open, sending nothing, ever.
+
+    Holding a reference is the point -- letting the socket be garbage collected
+    would close it and turn the stall into a refusal, which is a different (and
+    conclusive) failure.
+    """
+    logger.info("stalling a coexist-port connection (no data will be sent)")
+    try:
+        while True:
+            # Swallow whatever the client sends (the SLCAN bring-up commands and
+            # the version ping) and answer NOTHING. Returning from this function
+            # would close the socket, which the peer reads as an abort -- a
+            # different, conclusive failure. The connection must stay open and
+            # silent until the peer itself gives up.
+            if not client.recv(65536):
+                break
+    except OSError:
+        pass
+    finally:
+        client.close()
+
+
+def _serve(port: int, device_host: str, mode: str, stop: threading.Event) -> None:
+    srv = socket.socket()
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", port))
+    srv.listen(8)
+    srv.settimeout(0.5)
+    logger.info(
+        "listening on 127.0.0.1:%s -> %s:%s (%s)",
+        port,
+        device_host,
+        port,
+        mode if port == COEXIST_PORT else "forward",
+    )
+    while not stop.is_set():
+        try:
+            client, _ = srv.accept()
+        except socket.timeout:
+            continue
+        except OSError:
+            break
+        if port == COEXIST_PORT and mode == "stall":
+            threading.Thread(target=_stall, args=(client,), daemon=True).start()
+        else:
+            threading.Thread(
+                target=_forward, args=(client, device_host, port), daemon=True
+            ).start()
+    srv.close()
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--device", required=True, help="real device IP, e.g. 192.168.1.169")
+    ap.add_argument(
+        "--mode",
+        choices=("stall", "drop", "pass"),
+        default="stall",
+        help="behaviour of the coexistence port 35001",
+    )
+    args = ap.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s proxy: %(message)s")
+
+    ports = list(ALWAYS_FORWARD)
+    if args.mode != "drop":
+        ports.append(COEXIST_PORT)
+    else:
+        logger.info(
+            "mode=drop: NOT listening on %s, so the OS will refuse the connect "
+            "(the conclusive old-firmware case)",
+            COEXIST_PORT,
+        )
+
+    stop = threading.Event()
+    threads = [
+        threading.Thread(
+            target=_serve, args=(p, args.device, args.mode, stop), daemon=True
+        )
+        for p in ports
+    ]
+    for t in threads:
+        t.start()
+    logger.info("proxy up (mode=%s). Ctrl-C to stop.", args.mode)
+    try:
+        while True:
+            for t in threads:
+                t.join(0.5)
+    except KeyboardInterrupt:
+        logger.info("stopping")
+        stop.set()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,3 +77,24 @@ def mock_uds(mock_j2534_device):
     from src.ecu.transport import J2534Transport
 
     return UDSConnection(J2534Transport(mock_j2534_device, channel_id=1))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_wican_sidecars(tmp_path_factory, monkeypatch):
+    """Never let a test write a WiCAN sidecar into the user's real directory.
+
+    The protocol/datalog sidecars live in ``~/.nc-flash`` so a temp clean cannot
+    destroy the record of a stranded adapter (#92). That makes stray test writes
+    worse than untidy: the app's start-up sweep reads that directory, so a
+    leaked breadcrumb naming a host from a fixture would send the real app off
+    trying to recover a device that never existed.
+
+    Autouse, so isolation is the default and no future test has to remember.
+    Per-test fixtures that redirect the same helpers still win, since they are
+    applied after this one.
+    """
+    import src.ecu.wican_config as mod
+
+    sidecars = tmp_path_factory.mktemp("wican_sidecars")
+    monkeypatch.setattr(mod, "_sidecar_dir", lambda: str(sidecars))
+    monkeypatch.setattr(mod.tempfile, "gettempdir", lambda: str(sidecars))

--- a/tests/test_bench_coexist_probe_sockets.py
+++ b/tests/test_bench_coexist_probe_sockets.py
@@ -1,0 +1,119 @@
+"""Real-socket checks for the coexistence probe verdicts (#92).
+
+These exist because a mocked exception cannot pin OS behaviour. The unit test
+``test_connect_refused_is_conclusive_old_firmware`` sets ``__cause__`` to a
+``ConnectionRefusedError`` and passes -- while the real thing FAILED on the
+bench, because Windows does not deliver that error inside the probe's 1.5 s
+budget. Winsock receives the RST for a closed port and deliberately ignores it,
+retransmitting the SYN on its own schedule; the refusal only surfaces once that
+schedule is exhausted, measured at ~2.0 s on default settings. So a genuinely
+pre-coexistence adapter looked like a network fault and would have been refused
+a connect -- exactly the "protect ourselves by breaking old hardware" outcome
+the guard test was written to prevent, invisible to the guard test.
+
+Real sockets are the only thing that can catch that class of drift, so this runs
+against a genuinely closed local port. No device, no network, ~4 s.
+
+    venv-windows\\Scripts\\python.exe -m pytest tests/test_bench_coexist_probe_sockets.py -m bench
+
+Deselected from normal runs by the ``bench`` marker.
+"""
+
+import socket
+import time
+
+import pytest
+
+from src.ecu.constants import WICAN_DEDICATED_SLCAN_PORT, COEXIST_PROBE_TIMEOUT_MS
+from src.ecu.session import ECUSession, ProbeVerdict, _COEXIST_PROBE_RETRY_MS
+
+pytestmark = pytest.mark.bench
+
+
+@pytest.fixture
+def _qapp():
+    from PySide6.QtWidgets import QApplication
+
+    return QApplication.instance() or QApplication([])
+
+
+def _port_is_free(port: int) -> bool:
+    """True when nothing is listening on the loopback ``port``."""
+    probe = socket.socket()
+    probe.settimeout(0.5)
+    try:
+        probe.connect(("127.0.0.1", port))
+    except OSError:
+        return True
+    else:
+        return False
+    finally:
+        probe.close()
+
+
+def test_real_refused_port_is_conclusive_old_firmware(_qapp):
+    """A really-closed port must reach OLD_FIRMWARE, not INCONCLUSIVE.
+
+    This is the regression the bench caught. If it ever fails again, legacy
+    adapters are being refused: either the OS refusal latency now exceeds
+    ``_COEXIST_PROBE_RETRY_MS``, or the cause chain stopped carrying
+    ``ConnectionRefusedError``.
+    """
+    if not _port_is_free(WICAN_DEDICATED_SLCAN_PORT):
+        pytest.skip(
+            f"something is listening on {WICAN_DEDICATED_SLCAN_PORT}; "
+            "this check needs a genuinely closed port"
+        )
+
+    session = ECUSession(
+        adapter_config={
+            "kind": "wican",
+            "host": "127.0.0.1",
+            "port": 35000,
+            "auto_config": True,
+        }
+    )
+
+    started = time.monotonic()
+    transport, verdict = session._try_open_coexist_port()
+    elapsed_ms = (time.monotonic() - started) * 1000
+
+    assert transport is None
+    assert verdict is ProbeVerdict.OLD_FIRMWARE, (
+        f"a closed port was classified {verdict.value!r} after {elapsed_ms:.0f} ms. "
+        "Legacy adapters would now be refused a connect. If the refusal simply "
+        "arrived late, raise _COEXIST_PROBE_RETRY_MS "
+        f"(currently {_COEXIST_PROBE_RETRY_MS} ms)."
+    )
+    # It must also resolve within the budget we actually promise the user: the
+    # first attempt, plus the one confirming retry, plus slack for scheduling.
+    budget_ms = COEXIST_PROBE_TIMEOUT_MS + _COEXIST_PROBE_RETRY_MS + 2000
+    assert elapsed_ms < budget_ms, (
+        f"probe took {elapsed_ms:.0f} ms, over the {budget_ms} ms budget"
+    )
+
+
+def test_real_unreachable_host_is_inconclusive(_qapp):
+    """A black-holed address must stay INCONCLUSIVE, so no mode write happens.
+
+    The counterpart to the test above: a refusal is conclusive, silence is not.
+    192.0.2.1 is TEST-NET-1 (RFC 5737) -- reserved for documentation and never
+    routed, so packets are dropped rather than answered.
+    """
+    session = ECUSession(
+        adapter_config={
+            "kind": "wican",
+            "host": "192.0.2.1",
+            "port": 35000,
+            "auto_config": True,
+        }
+    )
+
+    transport, verdict = session._try_open_coexist_port()
+
+    assert transport is None
+    assert verdict is ProbeVerdict.INCONCLUSIVE, (
+        f"an unroutable host was classified {verdict.value!r}; anything other "
+        "than INCONCLUSIVE would authorise rewriting a device's stored mode on "
+        "no evidence, which is the #92 defect"
+    )

--- a/tests/test_bench_coexist_probe_sockets.py
+++ b/tests/test_bench_coexist_probe_sockets.py
@@ -88,9 +88,9 @@ def test_real_refused_port_is_conclusive_old_firmware(_qapp):
     # It must also resolve within the budget we actually promise the user: the
     # first attempt, plus the one confirming retry, plus slack for scheduling.
     budget_ms = COEXIST_PROBE_TIMEOUT_MS + _COEXIST_PROBE_RETRY_MS + 2000
-    assert elapsed_ms < budget_ms, (
-        f"probe took {elapsed_ms:.0f} ms, over the {budget_ms} ms budget"
-    )
+    assert (
+        elapsed_ms < budget_ms
+    ), f"probe took {elapsed_ms:.0f} ms, over the {budget_ms} ms budget"
 
 
 def test_real_unreachable_host_is_inconclusive(_qapp):

--- a/tests/test_ecu_session_coexist.py
+++ b/tests/test_ecu_session_coexist.py
@@ -2,9 +2,11 @@
 (``ECUSession._try_open_coexist_port``).
 
 The probe opens the always-on dedicated SLCAN port, version-pings it, and only
-adopts it when the firmware rev is new enough (``COEXIST_MIN_FW_REV``). Every
-failure mode must degrade to ``None`` so the caller falls back to the proven
-reboot-switch path — the probe must NEVER raise.
+adopts it when the firmware rev is new enough (``COEXIST_MIN_FW_REV``). It must
+NEVER raise — but it must report WHY it failed, because only CONCLUSIVE evidence
+of old firmware (a refused connect, or a real marker below the threshold) may
+authorise the caller to reboot the device into bench mode. An inconclusive
+failure that took the legacy path is what stranded devices in #92.
 """
 
 import socket
@@ -12,7 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.ecu.session import ECUSession, ECUSessionState
+from src.ecu.session import ECUSession, ECUSessionState, ProbeVerdict
 from src.ecu.constants import (
     WICAN_DEDICATED_SLCAN_PORT,
     COEXIST_MIN_FW_REV,
@@ -53,9 +55,10 @@ class TestCoexistProbe:
         with patch(
             "src.ecu.transport.create_ecu_transport", return_value=probe
         ) as mock_create:
-            result = _session(_qapp)._try_open_coexist_port()
+            result, verdict = _session(_qapp)._try_open_coexist_port()
 
-        assert result is probe  # adopted — handed back OPEN
+        assert result is probe  # adopted -- handed back OPEN
+        assert verdict is ProbeVerdict.COEXIST
         probe.open.assert_called_once()
         probe.close.assert_not_called()
         # Probed the dedicated port with the short capability timeout.
@@ -66,37 +69,59 @@ class TestCoexistProbe:
     def test_newer_firmware_adopted(self, _qapp):
         probe = _fake_probe(b"NCFRv%d" % (COEXIST_MIN_FW_REV + 3))
         with patch("src.ecu.transport.create_ecu_transport", return_value=probe):
-            assert _session(_qapp)._try_open_coexist_port() is probe
+            result, verdict = _session(_qapp)._try_open_coexist_port()
+        assert result is probe
+        assert verdict is ProbeVerdict.COEXIST
 
     def test_old_firmware_rejected_and_closed(self, _qapp):
         # A pre-coexistence build (e.g. the fastwrite NCFRv5) answers the port but
-        # is below the threshold → reject and close, fall back to reboot path.
+        # is below the threshold. A REAL marker is conclusive evidence, so the
+        # legacy reboot path -- and its mode write -- stays correct here.
         probe = _fake_probe(b"NCFRv%d" % (COEXIST_MIN_FW_REV - 1))
         with patch("src.ecu.transport.create_ecu_transport", return_value=probe):
-            assert _session(_qapp)._try_open_coexist_port() is None
+            result, verdict = _session(_qapp)._try_open_coexist_port()
+        assert result is None
+        assert verdict is ProbeVerdict.OLD_FIRMWARE
         probe.close.assert_called_once()
 
-    def test_no_marker_rejected_and_closed(self, _qapp):
-        probe = _fake_probe(None)  # port open but no NCFRv marker
+    def test_no_marker_is_inconclusive_not_old_firmware(self, _qapp):
+        # The port ACCEPTED the connection and then said nothing. Only the
+        # coexistence listener ever binds that port, so silence is far more
+        # likely to be a slow link than old firmware -- and it must not be
+        # treated as permission to rewrite the device's mode (#92).
+        probe = _fake_probe(None)
         with patch("src.ecu.transport.create_ecu_transport", return_value=probe):
-            assert _session(_qapp)._try_open_coexist_port() is None
+            result, verdict = _session(_qapp)._try_open_coexist_port()
+        assert result is None
+        assert verdict is ProbeVerdict.INCONCLUSIVE
+        # Silence earns one longer retry before we give up on it.
+        assert probe.version_ping.call_count == 2
         probe.close.assert_called_once()
 
-    def test_connect_refused_returns_none(self, _qapp):
-        # Old firmware has no dedicated port → TCP connect refused. Must not raise.
+    def test_connect_refused_is_conclusive_old_firmware(self, _qapp):
+        # Old firmware has no dedicated port -> the OS refuses the connect.
+        # Nothing is listening, which IS proof. Note the cause chain, not the
+        # message, is what the implementation inspects.
         probe = MagicMock()
-        probe.open.side_effect = WiCANError("connection refused")
+        err = WiCANError("connection refused")
+        err.__cause__ = ConnectionRefusedError(111, "Connection refused")
+        probe.open.side_effect = err
         with patch("src.ecu.transport.create_ecu_transport", return_value=probe):
-            assert _session(_qapp)._try_open_coexist_port() is None
+            result, verdict = _session(_qapp)._try_open_coexist_port()
+        assert result is None
+        assert verdict is ProbeVerdict.OLD_FIRMWARE
         probe.close.assert_called_once()
 
-    def test_create_transport_raises_returns_none(self, _qapp):
+    def test_create_transport_raises_is_inconclusive(self, _qapp):
         with patch(
             "src.ecu.transport.create_ecu_transport",
             side_effect=RuntimeError("boom"),
         ):
-            # No probe was created, nothing to close — just a clean None.
-            assert _session(_qapp)._try_open_coexist_port() is None
+            # No probe was created, nothing to close. An unexpected error proves
+            # nothing about the firmware, so it must not license a mode write.
+            result, verdict = _session(_qapp)._try_open_coexist_port()
+        assert result is None
+        assert verdict is ProbeVerdict.INCONCLUSIVE
 
 
 # ---------------------------------------------------------------------------
@@ -154,6 +179,11 @@ def _connect_with_probe_error(_qapp, err):
         inst = MockCfg.return_value
         inst.read_recovery.return_value = None
         inst.current_protocol.return_value = "poll_log"
+        # Explicit: this models TODAY's fleet, which has no /host_caps endpoint.
+        # Without this the guard would receive a truthy MagicMock and fall into
+        # the fallback branch by accident of mock semantics rather than by test
+        # design -- and the branch this test claims to cover would be untested.
+        inst.host_caps.return_value = None
 
         session = ECUSession(adapter_config=dict(WICAN_CFG))
         lost = []
@@ -195,3 +225,71 @@ class TestProbeInconclusivePolicy:
         inst.write_recovery.assert_called_once_with("poll_log")
         inst.set_protocol.assert_called_once_with("slcan")
         assert session.state == ECUSessionState.CONNECTED
+
+
+class TestInconclusiveGuardUsesHostCaps:
+    """#92: what the guard does with /host_caps, including the WRITE branch.
+
+    These branches decide whether the tool may reboot a device into bench mode.
+    They currently never execute anywhere -- the endpoint does not exist in
+    firmware yet -- so without these tests an inverted comparison here would
+    re-create the original defect the day that firmware ships, silently.
+    """
+
+    @staticmethod
+    def _guard(_qapp, caps, stored="poll_log"):
+        cfg = MagicMock()
+        cfg.host_caps.return_value = caps
+        cfg.current_protocol.return_value = stored
+        return _session(_qapp)._guard_inconclusive_probe(cfg), cfg
+
+    def test_caps_confirming_coexistence_refuses_the_write(self, _qapp):
+        # The device SAYS it has no-reboot firmware, but its port did not answer.
+        # There is nothing to connect to and no justification for a mode write.
+        from src.ecu.exceptions import CoexistProbeInconclusive
+
+        with pytest.raises(CoexistProbeInconclusive):
+            self._guard(_qapp, {"ncfr_rev": COEXIST_MIN_FW_REV, "protocol": "poll_log"})
+
+    def test_caps_reporting_old_firmware_allows_the_write(self, _qapp):
+        # A rev BELOW the threshold is conclusive: this really is a build with
+        # no dedicated port, so the legacy reboot path is the correct answer.
+        # Returning (rather than raising) is what authorises the write.
+        result, cfg = self._guard(
+            _qapp, {"ncfr_rev": COEXIST_MIN_FW_REV - 1, "protocol": "poll_log"}
+        )
+        assert result is None
+        cfg.current_protocol.assert_not_called()  # settled without the config blob
+
+    def test_caps_absent_falls_back_to_the_stored_protocol(self, _qapp):
+        # Today's fleet: no /host_caps. Must fall back, not treat the missing
+        # endpoint as evidence of anything.
+        from src.ecu.exceptions import CoexistProbeInconclusive
+
+        with pytest.raises(CoexistProbeInconclusive):
+            self._guard(_qapp, None, stored="poll_log")
+
+    def test_caps_absent_and_already_slcan_allows_the_write_free_path(self, _qapp):
+        # Already in slcan: the legacy path performs NO write, so continuing is
+        # safe -- and refusing here would lock the user out of a device this
+        # tool may itself have stranded earlier.
+        result, _cfg = self._guard(_qapp, None, stored="slcan")
+        assert result is None
+
+    def test_non_integer_rev_is_treated_as_absent(self, _qapp):
+        # A firmware that answers with "6" instead of 6 must not be trusted as a
+        # number; fall back rather than guess.
+        from src.ecu.exceptions import CoexistProbeInconclusive
+
+        with pytest.raises(CoexistProbeInconclusive):
+            self._guard(_qapp, {"ncfr_rev": "6"}, stored="poll_log")
+
+    def test_unreachable_over_http_too_refuses(self, _qapp):
+        from src.ecu.exceptions import CoexistProbeInconclusive
+        from src.ecu.wican_config import WiCANConfigError
+
+        cfg = MagicMock()
+        cfg.host_caps.return_value = None
+        cfg.current_protocol.side_effect = WiCANConfigError("cannot reach")
+        with pytest.raises(CoexistProbeInconclusive):
+            _session(_qapp)._guard_inconclusive_probe(cfg)

--- a/tests/test_ecu_session_coexist.py
+++ b/tests/test_ecu_session_coexist.py
@@ -7,11 +7,12 @@ failure mode must degrade to ``None`` so the caller falls back to the proven
 reboot-switch path — the probe must NEVER raise.
 """
 
+import socket
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.ecu.session import ECUSession
+from src.ecu.session import ECUSession, ECUSessionState
 from src.ecu.constants import (
     WICAN_DEDICATED_SLCAN_PORT,
     COEXIST_MIN_FW_REV,
@@ -96,3 +97,101 @@ class TestCoexistProbe:
         ):
             # No probe was created, nothing to close — just a clean None.
             assert _session(_qapp)._try_open_coexist_port() is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #92 — an INCONCLUSIVE probe must never rewrite the device's stored mode.
+#
+# The probe today collapses every failure into ``None``, so the caller takes the
+# legacy path and writes ``protocol: slcan`` into stored config. That is correct
+# when the failure PROVES old firmware (nothing listens on 35001 -> the OS
+# refuses the connect), and wrong when it proves nothing (a timeout on a device
+# that is otherwise perfectly reachable). The second case can strand the device
+# in Bench SLCAN with the datalogger dead.
+#
+# The rule these tests pin down:
+#   conclusive failure  -> legacy path, mode write allowed  (test_..._guard)
+#   inconclusive failure -> refuse to write, fail loudly    (the rest)
+# ---------------------------------------------------------------------------
+
+
+def _timeout_error():
+    """A probe failure shaped like a real connect timeout (proves nothing)."""
+    err = WiCANError("Failed to connect to 192.168.1.169:35001: timed out")
+    err.__cause__ = socket.timeout("timed out")
+    return err
+
+
+def _refused_error():
+    """A probe failure shaped like a real TCP refusal (proves old firmware)."""
+    err = WiCANError("Failed to connect to 192.168.1.169:35001: refused")
+    err.__cause__ = ConnectionRefusedError(111, "Connection refused")
+    return err
+
+
+def _connect_with_probe_error(_qapp, err):
+    """Drive a full connect where ONLY the coexist probe fails with ``err``.
+
+    Port 35000 (the legacy data port) still opens fine, so the device is
+    "otherwise reachable" — exactly the situation where a mode write is unsafe.
+    Returns (session, configurator_mock, connection_lost_messages).
+    """
+    legacy = MagicMock()
+
+    def _by_port(cfg, *a, **kw):
+        if cfg.get("port") == WICAN_DEDICATED_SLCAN_PORT:
+            probe = MagicMock()
+            probe.open.side_effect = err
+            return probe
+        return legacy
+
+    with (
+        patch("src.ecu.wican_config.WiCANConfigurator") as MockCfg,
+        patch("src.ecu.wican_config.WiCANDatalogClient"),
+        patch("src.ecu.transport.create_ecu_transport", side_effect=_by_port),
+        patch("src.ecu.protocol.UDSConnection"),
+    ):
+        inst = MockCfg.return_value
+        inst.read_recovery.return_value = None
+        inst.current_protocol.return_value = "poll_log"
+
+        session = ECUSession(adapter_config=dict(WICAN_CFG))
+        lost = []
+        session.connection_lost.connect(lost.append)
+        session.connect_ecu()
+
+    return session, inst, lost
+
+
+class TestProbeInconclusivePolicy:
+    """#92: a probe that proves nothing must not reboot the device into slcan."""
+
+    def test_timeout_does_not_write_slcan(self, _qapp):
+        # The coexist port timed out but port 35000 is fine — the device is up,
+        # we simply could not confirm its capability. Writing the mode here is
+        # what strands it, so the connect must fail instead.
+        session, inst, lost = _connect_with_probe_error(_qapp, _timeout_error())
+
+        inst.set_protocol.assert_not_called()
+        inst.write_recovery.assert_not_called()
+
+    def test_timeout_fails_loudly(self, _qapp):
+        # Refusing must be visible. A silent no-op would look like a hung app.
+        session, inst, lost = _connect_with_probe_error(_qapp, _timeout_error())
+
+        assert session.state == ECUSessionState.DISCONNECTED
+        assert len(lost) == 1, f"expected one connection_lost, got {lost!r}"
+
+    def test_refused_still_takes_legacy_path_guard(self, _qapp):
+        """GUARD — green before AND after the fix.
+
+        A refused TCP connect proves nothing is listening on 35001, i.e. genuine
+        pre-coexistence firmware. Those users have no other way in, so the mode
+        write must keep working for them. This pins the other side of the rule so
+        the fix cannot 'protect' us by breaking old hardware.
+        """
+        session, inst, lost = _connect_with_probe_error(_qapp, _refused_error())
+
+        inst.write_recovery.assert_called_once_with("poll_log")
+        inst.set_protocol.assert_called_once_with("slcan")
+        assert session.state == ECUSessionState.CONNECTED

--- a/tests/test_ecu_session_wican.py
+++ b/tests/test_ecu_session_wican.py
@@ -375,3 +375,32 @@ class TestWiCANAcquire:
             assert channel_id is None
             assert filter_id is None
             assert uds is MockUDS.return_value
+
+
+class TestFailedRestoreKeepsBreadcrumb:
+    """#92: when the restore fails, the crash-recovery record must survive.
+
+    ``_restore_wican_protocol`` swallows a failed restore and then clears the
+    breadcrumb in a ``finally``. That combination is what makes a strand
+    permanent: the device is still in slcan, and the only record of the user's
+    real mode has just been deleted, so nothing can ever put it back
+    automatically.
+    """
+
+    def test_failed_restore_does_not_clear_breadcrumb(self, _qapp):
+        from src.ecu.wican_config import WiCANConfigError
+
+        with (
+            patch("src.ecu.wican_config.WiCANConfigurator") as MockCfg,
+            patch("src.ecu.transport.create_ecu_transport"),
+            patch("src.ecu.protocol.UDSConnection"),
+        ):
+            inst = _cfg(MockCfg, prev="realdash")
+            inst.restore.side_effect = WiCANConfigError("device unreachable")
+
+            session = _make_session(_qapp)
+            session.connect_ecu()
+            session.disconnect_ecu()
+
+            inst.restore.assert_called_once_with("realdash")
+            inst.clear_recovery.assert_not_called()

--- a/tests/test_ecu_session_wican.py
+++ b/tests/test_ecu_session_wican.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.ecu.session import ECUSession, ECUSessionState
+from src.ecu.session import ECUSession, ECUSessionState, ProbeVerdict
 from src.ecu.wican_transport import WiCANError
 
 WICAN_CFG = {
@@ -36,7 +36,11 @@ def _default_no_coexist():
     would otherwise fire against the mocked ``create_ecu_transport`` and skew the
     open/switch assertions. The coexist-path tests below re-patch this to return
     a transport, which overrides this default for their duration."""
-    with patch.object(ECUSession, "_try_open_coexist_port", return_value=None):
+    with patch.object(
+        ECUSession,
+        "_try_open_coexist_port",
+        return_value=(None, ProbeVerdict.OLD_FIRMWARE),
+    ):
         yield
 
 
@@ -141,7 +145,9 @@ class TestWiCANCoexistConnect:
             patch("src.ecu.transport.create_ecu_transport") as mock_create,
             patch("src.ecu.protocol.UDSConnection") as MockUDS,
             patch.object(
-                ECUSession, "_try_open_coexist_port", return_value=coexist_transport
+                ECUSession,
+                "_try_open_coexist_port",
+                return_value=(coexist_transport, ProbeVerdict.COEXIST),
             ),
         ):
             session = _make_session(_qapp)
@@ -164,7 +170,9 @@ class TestWiCANCoexistConnect:
             patch("src.ecu.transport.create_ecu_transport"),
             patch("src.ecu.protocol.UDSConnection"),
             patch.object(
-                ECUSession, "_try_open_coexist_port", return_value=coexist_transport
+                ECUSession,
+                "_try_open_coexist_port",
+                return_value=(coexist_transport, ProbeVerdict.COEXIST),
             ),
         ):
             session = _make_session(_qapp)
@@ -190,7 +198,9 @@ class TestWiCANCoexistConnect:
             patch("src.ecu.transport.create_ecu_transport"),
             patch("src.ecu.protocol.UDSConnection") as MockUDS,
             patch.object(
-                ECUSession, "_try_open_coexist_port", return_value=coexist_transport
+                ECUSession,
+                "_try_open_coexist_port",
+                return_value=(coexist_transport, ProbeVerdict.COEXIST),
             ),
         ):
             datalog = MockDatalog.return_value
@@ -228,7 +238,9 @@ class TestWiCANCoexistConnect:
             patch("src.ecu.transport.create_ecu_transport"),
             patch("src.ecu.protocol.UDSConnection") as MockUDS,
             patch.object(
-                ECUSession, "_try_open_coexist_port", return_value=coexist_transport
+                ECUSession,
+                "_try_open_coexist_port",
+                return_value=(coexist_transport, ProbeVerdict.COEXIST),
             ),
         ):
             MockDatalog.return_value.acquire_bus.side_effect = lambda: calls.append(

--- a/tests/test_ecu_wican_config.py
+++ b/tests/test_ecu_wican_config.py
@@ -920,7 +920,9 @@ def test_failed_restore_keeps_the_breadcrumb(_recovery_in_tmp, monkeypatch):
         # The device is still in slcan and the restore failed. The sidecar is now
         # the only thing that knows the user was on poll_log — losing it here is
         # what makes a strand permanent.
-        assert os.path.exists(cfg.recovery_path), "sidecar deleted after a FAILED restore"
+        assert os.path.exists(
+            cfg.recovery_path
+        ), "sidecar deleted after a FAILED restore"
         assert cfg.read_recovery() == "poll_log"
 
 

--- a/tests/test_ecu_wican_config.py
+++ b/tests/test_ecu_wican_config.py
@@ -876,3 +876,71 @@ def test_datalog_keepalive_stops_on_close(_recovery_in_tmp):
         client.close()
         assert client._ka_thread is None
         assert client._park_token is None and client._claim_token is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #92 — the breadcrumb is the ONLY record of the user's original mode.
+# If the restore fails, that record must survive so a later run can undo the
+# strand. Today both restore paths delete it in a ``finally``, which turns a
+# recoverable failure into a permanent one.
+# ---------------------------------------------------------------------------
+
+
+def test_failed_restore_keeps_the_breadcrumb(_recovery_in_tmp, monkeypatch):
+    """slcan_session(): a restore that raises must NOT clear the sidecar."""
+    with _MockWiCANServer(REALISTIC_CONFIG) as server:
+        cfg = _make_configurator(server)
+
+        with pytest.raises(WiCANConfigError):
+            with cfg.slcan_session() as prev:
+                assert prev == "poll_log"
+                # The breadcrumb exists while we hold the session.
+                assert cfg.read_recovery() == "poll_log"
+
+                def _boom(_protocol):
+                    raise WiCANConfigError("device went away mid-restore")
+
+                monkeypatch.setattr(cfg, "restore", _boom)
+
+        # The device is still in slcan and the restore failed. The sidecar is now
+        # the only thing that knows the user was on poll_log — losing it here is
+        # what makes a strand permanent.
+        assert os.path.exists(cfg.recovery_path), "sidecar deleted after a FAILED restore"
+        assert cfg.read_recovery() == "poll_log"
+
+
+# ---------------------------------------------------------------------------
+# Issue #92 — recovery must not depend on the user reconnecting.
+#
+# Today a stranded device is only ever un-stranded inside a later successful
+# connect to that same host. If the user gives up on the tool (the natural
+# reaction to "my logger stopped working"), nothing ever restores it. This is a
+# CONTRACT test for a seam that does not exist yet: it fails on ImportError
+# today, so unlike the tests above it cannot disprove anything -- it defines the
+# API the fix must provide.
+# ---------------------------------------------------------------------------
+
+
+def test_startup_sweep_restores_a_stranded_device(_recovery_in_tmp):
+    """A breadcrumb + a device sitting in slcan is enough to recover it.
+
+    No ECUSession, no connect, no GUI -- just the sweep a fresh app launch runs.
+    """
+    from src.ecu.wican_config import recover_stranded_protocols
+
+    with _MockWiCANServer(_slcan_config()) as server:
+        # Exactly what a hard-killed run leaves behind: the device is in slcan
+        # and a sidecar remembers the user was on poll_log.
+        stranded = WiCANConfigurator("127.0.0.1", http_port=server.port)
+        stranded._write_recovery("poll_log")
+
+        records = recover_stranded_protocols(
+            http_port=server.port,
+            confirm=lambda host, previous: True,
+        )
+
+        assert get_top_level_protocol(server.config) == "poll_log"
+        assert len(server.posts) == 1, "the sweep must write exactly once"
+        assert not os.path.exists(stranded.recovery_path)
+        assert [r["action"] for r in records] == ["restored"]
+        assert records[0]["host"] == "127.0.0.1"

--- a/tests/test_ecu_wican_config.py
+++ b/tests/test_ecu_wican_config.py
@@ -60,6 +60,9 @@ class _MockWiCANServer:
 
     def __init__(self, config: str):
         self.config = config
+        #: Body served at /host_caps. None => 404, i.e. every build in the field
+        #: today, which predates the endpoint.
+        self.host_caps_body = None
         self.posts: list[str] = []
         self.fail_gets_after_post = 0
         self._pending_get_failures = 0
@@ -80,6 +83,12 @@ class _MockWiCANServer:
                 self.wfile.write(payload)
 
             def do_GET(self):
+                if self.path == "/host_caps":
+                    if server.host_caps_body is None:
+                        self._send_text(404, "not found")
+                    else:
+                        self._send_text(200, server.host_caps_body)
+                    return
                 if self.path != "/load_config":
                     self._send_text(404, "not found")
                     return
@@ -334,7 +343,13 @@ def _recovery_in_tmp(tmp_path, monkeypatch):
     """Point the recovery sidecar at an isolated temp dir for the test."""
     import src.ecu.wican_config as mod
 
-    monkeypatch.setattr(mod.tempfile, "gettempdir", lambda: str(tmp_path))
+    # The sidecars now live under ~/.nc-flash (a temp clean must not destroy the
+    # only record of a stranded device). Redirect BOTH the new home and the
+    # legacy OS-temp location so a test can never touch either real directory.
+    legacy = tmp_path / "legacy_temp"
+    legacy.mkdir(exist_ok=True)
+    monkeypatch.setattr(mod, "_sidecar_dir", lambda: str(tmp_path))
+    monkeypatch.setattr(mod.tempfile, "gettempdir", lambda: str(legacy))
     return tmp_path
 
 
@@ -944,3 +959,218 @@ def test_startup_sweep_restores_a_stranded_device(_recovery_in_tmp):
         assert not os.path.exists(stranded.recovery_path)
         assert [r["action"] for r in records] == ["restored"]
         assert records[0]["host"] == "127.0.0.1"
+
+
+def _sweep_with_datalog_state(monkeypatch, state):
+    """Make the sweep see ``state`` from /datalog without a real endpoint."""
+    import src.ecu.wican_config as mod
+
+    class _Stub:
+        def __init__(self, host, http_port=80, **kw):
+            pass
+
+        def get_state(self):
+            return state
+
+    monkeypatch.setattr(mod, "WiCANDatalogClient", _Stub)
+
+
+def test_sweep_refuses_while_a_flash_is_active(_recovery_in_tmp, monkeypatch):
+    """BRICK GUARD: never reboot a device that is mid-flash.
+
+    The stranded device may be stranded *because* another machine is flashing
+    through it right now. Rebooting it there can leave the car's ECU half
+    written, which is unrecoverable from this app.
+    """
+    from src.ecu.wican_config import recover_stranded_protocols
+
+    _sweep_with_datalog_state(monkeypatch, {"flash_active": True})
+    with _MockWiCANServer(_slcan_config()) as server:
+        cfg = WiCANConfigurator("127.0.0.1", http_port=server.port)
+        cfg._write_recovery("poll_log")
+
+        records = recover_stranded_protocols(
+            http_port=server.port, confirm=lambda *a: True
+        )
+
+        assert [r["action"] for r in records] == ["busy"]
+        assert server.posts == [], "wrote to a device that is mid-flash"
+        assert os.path.exists(cfg.recovery_path), "sidecar dropped while busy"
+
+
+def test_sweep_refuses_while_a_host_holds_the_bus(_recovery_in_tmp, monkeypatch):
+    """Same guard for the pre-flash auth window, which no flash flag covers."""
+    from src.ecu.wican_config import recover_stranded_protocols
+
+    _sweep_with_datalog_state(monkeypatch, {"host_bus_claimed": True})
+    with _MockWiCANServer(_slcan_config()) as server:
+        cfg = WiCANConfigurator("127.0.0.1", http_port=server.port)
+        cfg._write_recovery("poll_log")
+
+        records = recover_stranded_protocols(
+            http_port=server.port, confirm=lambda *a: True
+        )
+
+        assert [r["action"] for r in records] == ["busy"]
+        assert server.posts == []
+        assert os.path.exists(cfg.recovery_path)
+
+
+def test_sweep_drops_a_stale_sidecar_without_touching_the_device(_recovery_in_tmp):
+    """Device already back on poll_log: clean up, but never write to it."""
+    from src.ecu.wican_config import recover_stranded_protocols
+
+    with _MockWiCANServer(REALISTIC_CONFIG) as server:  # NOT slcan
+        cfg = WiCANConfigurator("127.0.0.1", http_port=server.port)
+        cfg._write_recovery("poll_log")
+
+        records = recover_stranded_protocols(http_port=server.port)
+
+        assert [r["action"] for r in records] == ["stale"]
+        assert server.posts == []
+        assert not os.path.exists(cfg.recovery_path)
+
+
+def test_sweep_keeps_the_sidecar_when_the_device_is_unreachable(_recovery_in_tmp):
+    """A device that is merely off must stay recoverable on a later launch."""
+    from src.ecu.wican_config import recover_stranded_protocols
+
+    cfg = WiCANConfigurator("127.0.0.1", http_port=9)  # discard port: nothing there
+    cfg._write_recovery("poll_log")
+
+    records = recover_stranded_protocols(http_port=9, timeout_s=0.4)
+
+    assert [r["action"] for r in records] == ["unreachable"]
+    assert os.path.exists(cfg.recovery_path)
+
+
+def test_sweep_honours_a_declined_confirmation(_recovery_in_tmp):
+    """Saying no leaves the device alone AND keeps the sidecar for next time."""
+    from src.ecu.wican_config import recover_stranded_protocols
+
+    with _MockWiCANServer(_slcan_config()) as server:
+        cfg = WiCANConfigurator("127.0.0.1", http_port=server.port)
+        cfg._write_recovery("poll_log")
+
+        records = recover_stranded_protocols(
+            http_port=server.port, confirm=lambda host, prev: False
+        )
+
+        assert [r["action"] for r in records] == ["declined"]
+        assert server.posts == []
+        assert os.path.exists(cfg.recovery_path)
+
+
+def test_sweep_skips_a_host_with_a_live_session(_recovery_in_tmp):
+    """The GUI can exclude a device it is actively using."""
+    from src.ecu.wican_config import recover_stranded_protocols
+
+    with _MockWiCANServer(_slcan_config()) as server:
+        cfg = WiCANConfigurator("127.0.0.1", http_port=server.port)
+        cfg._write_recovery("poll_log")
+
+        records = recover_stranded_protocols(
+            http_port=server.port,
+            confirm=lambda *a: True,
+            should_skip=lambda host: host == "127.0.0.1",
+        )
+
+        assert [r["action"] for r in records] == ["skipped"]
+        assert server.posts == []
+        assert os.path.exists(cfg.recovery_path)
+
+
+# ---------------------------------------------------------------------------
+# /host_caps: the small, secret-free capability reply (#92).
+#
+# It exists so a host tool can settle "does this device support no-reboot
+# flashing?" by reading an integer, instead of inferring it from which socket
+# error arrived first on a marginal link -- an inference that was measured wrong
+# on Windows. Absent on every build in the field today, so "no endpoint" must
+# never be read as evidence about the firmware.
+# ---------------------------------------------------------------------------
+
+
+def test_host_caps_parses_a_good_reply():
+    with _MockWiCANServer(REALISTIC_CONFIG) as server:
+        server.host_caps_body = '{"ncfr_rev": 6, "protocol": "poll_log"}'
+        caps = _make_configurator(server).host_caps()
+    assert caps == {"ncfr_rev": 6, "protocol": "poll_log"}
+
+
+def test_host_caps_returns_none_when_absent():
+    # Today's firmware: 404. Must be None, NOT an exception and NOT a verdict.
+    with _MockWiCANServer(REALISTIC_CONFIG) as server:
+        assert server.host_caps_body is None
+        assert _make_configurator(server).host_caps() is None
+
+
+def test_host_caps_returns_none_on_garbage():
+    with _MockWiCANServer(REALISTIC_CONFIG) as server:
+        server.host_caps_body = "<html>not json</html>"
+        assert _make_configurator(server).host_caps() is None
+
+
+def test_host_caps_returns_none_on_a_json_non_object():
+    with _MockWiCANServer(REALISTIC_CONFIG) as server:
+        server.host_caps_body = "[1, 2, 3]"
+        assert _make_configurator(server).host_caps() is None
+
+
+def test_host_caps_never_raises_when_the_device_is_gone():
+    cfg = WiCANConfigurator("127.0.0.1", http_port=9, timeout_s=0.4)
+    assert cfg.host_caps() is None
+
+
+# ---------------------------------------------------------------------------
+# Upgrading from a pre-#92 build: sidecars used to live in the OS temp dir.
+# An upgrade must adopt them, or a device the OLD build stranded could never be
+# recovered automatically.
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_sidecar_is_adopted_and_moved(_recovery_in_tmp):
+    """read_recovery() finds a crumb the old build left in the OS temp dir."""
+    import src.ecu.wican_config as mod
+
+    cfg = WiCANConfigurator("192.168.0.10", http_port=80)
+    legacy = mod._legacy_host_keyed_temp_path("192.168.0.10", "wican_recovery")
+    assert legacy != cfg.recovery_path, "fixture must give two distinct dirs"
+    with open(legacy, "w", encoding="utf-8") as fh:
+        fh.write('{"host": "192.168.0.10", "previous_protocol": "poll_log"}')
+
+    assert cfg.read_recovery() == "poll_log"
+    # Adopted into the new home, and the old copy cleaned up so it cannot be
+    # picked up twice later.
+    assert os.path.exists(cfg.recovery_path)
+    assert not os.path.exists(legacy)
+
+
+def test_legacy_sidecar_for_another_host_is_ignored(_recovery_in_tmp):
+    """The host check still applies to a migrated file."""
+    import src.ecu.wican_config as mod
+
+    cfg = WiCANConfigurator("192.168.0.10", http_port=80)
+    legacy = mod._legacy_host_keyed_temp_path("192.168.0.10", "wican_recovery")
+    with open(legacy, "w", encoding="utf-8") as fh:
+        fh.write('{"host": "10.9.9.9", "previous_protocol": "poll_log"}')
+
+    assert cfg.read_recovery() is None
+
+
+def test_sweep_finds_a_sidecar_left_in_the_legacy_location(_recovery_in_tmp):
+    """A device stranded by the OLD build is still recovered after upgrading."""
+    import src.ecu.wican_config as mod
+    from src.ecu.wican_config import recover_stranded_protocols
+
+    with _MockWiCANServer(_slcan_config()) as server:
+        legacy = mod._legacy_host_keyed_temp_path("127.0.0.1", "wican_recovery")
+        with open(legacy, "w", encoding="utf-8") as fh:
+            fh.write('{"host": "127.0.0.1", "previous_protocol": "poll_log"}')
+
+        records = recover_stranded_protocols(
+            http_port=server.port, confirm=lambda *a: True
+        )
+
+        assert [r["action"] for r in records] == ["restored"]
+        assert get_top_level_protocol(server.config) == "poll_log"

--- a/tests/test_ecu_wican_sd_flash.py
+++ b/tests/test_ecu_wican_sd_flash.py
@@ -284,7 +284,13 @@ def _recovery_in_tmp(tmp_path, monkeypatch):
     """Isolate the datalog crash-recovery breadcrumb in a per-test temp dir."""
     import src.ecu.wican_config as mod
 
-    monkeypatch.setattr(mod.tempfile, "gettempdir", lambda: str(tmp_path))
+    # The sidecars now live under ~/.nc-flash (a temp clean must not destroy the
+    # only record of a stranded device). Redirect BOTH the new home and the
+    # legacy OS-temp location so a test can never touch either real directory.
+    legacy = tmp_path / "legacy_temp"
+    legacy.mkdir(exist_ok=True)
+    monkeypatch.setattr(mod, "_sidecar_dir", lambda: str(tmp_path))
+    monkeypatch.setattr(mod.tempfile, "gettempdir", lambda: str(legacy))
     return tmp_path
 
 


### PR DESCRIPTION
## Problem

A WiCAN left in Bench SLCAN mode stops datalogging, and nothing put it back. Flashing on
pre-coexistence firmware means rebooting the adapter into `slcan` and restoring it afterwards;
if that session died first, the device stayed that way — and the only cure was reconnecting to
the exact device that broke, which is the last thing someone whose logger just died does.

**Reproduced on real hardware before any fix was written** (`tests/bench/`). The decisive one:
with the breadcrumb gone, NC Flash connects, disconnects, **exits 0, and leaves the device
broken** — the tool reports success while the adapter is still stranded.

## Three defects, ranked by risk removed

1. **The breadcrumb was deleted even when the restore FAILED** — in both `slcan_session()` and
   `ECUSession._restore_wican_protocol()`, via a `finally`. That destroyed the only record of the
   user's real mode, turning a recoverable failure into a permanent one. Now cleared only after
   a restore actually returns; the session also keeps its switch state, so `cleanup()` gets a
   free second attempt.
2. **Recovery only ran inside a later connect to the same host.** New `recover_stranded_protocols()`
   sweep at start-up. It refuses while a flash or host bus-claim is live (rebooting a device
   mid-flash can leave the car's ECU half-written), keeps the sidecar on failure, drops stale ones
   without touching the device, skips a host this app is already using, and asks first — with the
   dialog defaulting to **No**, because on old firmware there is no `/datalog` to consult and that
   answer is the only gate.
3. **The probe treated *any* failure as "old firmware"** and rewrote the stored mode. It now
   returns a verdict: only a refused connect or a real `NCFRv` marker below the threshold
   authorises the write. A timeout, reset or silent port is `INCONCLUSIVE` — one longer retry,
   then a clear refusal.

Plus: sidecars moved to `~/.nc-flash` with migration (a temp clean could destroy them), and
**Settings > Test Connection**, which wrote `slcan` with *no breadcrumb at all* — one click plus a
crash stranded the device with nothing, not even the new sweep, able to find it.

## The bug the bench caught that no unit test could

Fable's policy rests on "refused connect = conclusive old firmware." On Windows that is measurably
false inside the probe budget: Winsock receives the RST for a closed port, **ignores it**, and
retransmits the SYN on its own schedule, so `ConnectionRefusedError` surfaces after **~2.0 s**
against a **1.5 s** budget. Genuinely old adapters would have been classified inconclusive and
**refused a connect** — the exact "protect ourselves by breaking old hardware" outcome the guard
test existed to prevent. The guard test passed anyway, because a mock's `__cause__` is whatever we
say it is.

Fixed with one confirming retry at 3 s that only failing paths pay (a healthy port connects in
~20 ms), the measured latency logged so the budget can be retuned from evidence, and pinned by a
**real-socket** test under a new `bench` marker — OS semantics can only be pinned by the OS.

## Testing

- **1712 passed, 12 skipped, 2 deselected**; `-m bench` → 2 passed.
- Bench, on the live device (fw v1.21.1, NCFRv6), all four criteria: stalled probe → refuses,
  device stays `poll_log`, no breadcrumb · refused port → legacy path still works, clean restore ·
  hand-stranded device → sweep restores it · healthy firmware → adopted in 0.47 s, mode untouched.
- `tests/bench/slcan_strand_proxy.py` reproduces the strand on demand (stall / drop / pass).

## Notes for review

- **Does not close #92.** The defects are real and now proven, but the probe succeeded 5/5 on the
  bench and the fallback fired exactly once across every log, with zero restore failures — the
  2026-08-11 incident stays unattributed.
- `WiCANConfigurator.host_caps()` targets a firmware endpoint that **does not exist yet**; its
  absence is explicitly never read as evidence about the firmware. Branch-covered by tests since
  it cannot be exercised against real firmware.
- An autouse `conftest.py` fixture now isolates sidecars: the suite was writing a real breadcrumb
  into `~/.nc-flash`. Harmless as it stood (a datalog crumb; the sweep only globs
  `wican_recovery_*`), but a protocol crumb leaked the same way would have mattered.
- Out of scope, firmware, designed separately: `/host_caps`, the running mode on the boot line, a
  flash-guarded one-click restore on the existing "PID Polling Inactive" banner, and a host-less
  auto-revert — the only measure that helps against a writer that isn't this copy of NC Flash.

Design and adversarial review by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
