### PR TITLE
fix(wican): stop giving up while the ECU is still erasing (#126)

### DIFF
--- a/src/ecu/wican_transport.py
+++ b/src/ecu/wican_transport.py
@@ -186,7 +186,19 @@ FAST_WRITE_TIMEOUT_MS = 600000
 
 #: Idle/heartbeat (ms): no bytes for this long means the firmware is dead, not
 #: merely slow. Generous because an ECU erase can sit silent for several seconds.
-_FAST_WRITE_IDLE_MS = 30000
+#:
+#: MUST stay comfortably above the firmware's RESP_ERASE_TIMEOUT_MS
+#: (nc-flash-wican-fw main/ncflash_fastwrite.c), which is how long the device
+#: lawfully waits without sending anything while the ECU erases. This was 30000,
+#: the SAME value the firmware used, and our clock starts at the previous progress
+#: line -- one to three seconds earlier -- so the host ALWAYS gave up first.
+#:
+#: That is not a cosmetic race. Giving up here closes the socket, the firmware's
+#: next progress write fails, its TX task stops draining, and the flash aborts via
+#: host_gone -- abandoning the ECU immediately after the erase, unbootable, while
+#: this side reports "stalled" and invites a key-cycle. 90 s against the firmware's
+#: 60 s leaves 30 s of margin. Change the two together (firmware issue #126).
+_FAST_WRITE_IDLE_MS = 90000
 
 
 class WiCANError(ECUError):


### PR DESCRIPTION
**Must merge together with `cdufresne81/nc-flash-wican-fw#128`** — neither side is safe alone. Raising this alone would just wait longer for a firmware that still gives up at 5 s.

## The bug

`_FAST_WRITE_IDLE_MS` was `30000` — the **same value** the firmware used as its erase ceiling — and our clock starts at the previous progress line, one to three seconds before the erase begins. So the host **always gave up first**.

That is not cosmetic. Raising "fast write stalled" closes the socket; the firmware's `slcan_port_tx_task` then parks on `PORT_OPEN` and stops draining, its next progress write fills the queue, `tx_send` times out, and the flash aborts via `host_gone` — abandoning the ECU immediately after its erase, unbootable, while this side reports a stall and invites the user to key-cycle a car that is mid-flash.

## The change

One constant: `30000` → `90000`, against the firmware's new 60 s ceiling. 30 s of margin.

The comment now records the coupling so nobody lowers it again without looking at the firmware.

## Why 90 and not more

Raising it further would only make a genuinely dead firmware take longer to notice. 90 s covers the worst legal silent window (~62 s: one erase-edge stall plus the blocks before the first progress line) with room to spare, and sits well inside the unchanged `FAST_WRITE_TIMEOUT_MS = 600000` total.

## Testing

- 1655 passed, 43 skipped.
- `black --check` clean; `flake8 --select=E9,F63,F7,F82` clean.
- Nothing in the test suite pinned the old value; the one test that exercises the idle path passes `idle_ms` explicitly.
- Only `wican_sd_flash.py:502` calls `fast_write` in production, and `idle_ms` is a keyword default, so explicit callers are unaffected.

## Review

Found by Fable's adversarial review, which returned **DO-NOT-SHIP** on the firmware-only version specifically because of this race. Final verdict on the pair: **SHIP**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACqDS5vAHP3oySMbDu8mgu